### PR TITLE
Add model init waiting overlay for login

### DIFF
--- a/frontend-react/src/components/LoadingOverlay.tsx
+++ b/frontend-react/src/components/LoadingOverlay.tsx
@@ -1,0 +1,18 @@
+import { Loader2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export default function LoadingOverlay({ show }: { show: boolean }) {
+  return (
+    <div
+      role="status"
+      aria-busy={show}
+      className={cn(
+        'fixed inset-0 z-40 flex flex-col items-center justify-center bg-white/60 backdrop-blur-sm transition-opacity duration-300 ease-out',
+        show ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
+      )}
+    >
+      <Loader2 className="h-12 w-12 animate-spin text-primary" />
+      <p className="mt-4 font-title text-primary">Modellen laden…</p>
+    </div>
+  );
+}

--- a/frontend-react/src/components/ui/input.tsx
+++ b/frontend-react/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          'flex h-10 w-full rounded-md border px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-primary',
+          'flex h-10 w-full rounded-md border px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-primary disabled:bg-slate-100 disabled:text-slate-500 disabled:cursor-not-allowed',
           className
         )}
         ref={ref}

--- a/frontend-react/src/lib/ModelInitContext.tsx
+++ b/frontend-react/src/lib/ModelInitContext.tsx
@@ -1,0 +1,33 @@
+import React, { createContext, useEffect, useState } from 'react';
+import { toast } from '@/components/ui/toast';
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const ModelInitContext = createContext<{ ready: boolean }>({ ready: false });
+
+export function ModelInitProvider({ children }: { children: React.ReactNode }) {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function init() {
+      try {
+        const r = await fetch('/api/initialize_models', { method: 'POST' });
+        if (!r.ok) throw new Error('Initialiseren mislukt');
+        await r.text();
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        toast({ title: 'Fout', description: message, variant: 'destructive' });
+      } finally {
+        if (!cancelled) setReady(true);
+      }
+    }
+    init();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <ModelInitContext.Provider value={{ ready }}>{children}</ModelInitContext.Provider>
+  );
+}

--- a/frontend-react/src/main.tsx
+++ b/frontend-react/src/main.tsx
@@ -3,14 +3,17 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import './index.css';
 import LoginPage from './pages/LoginPage';
+import { ModelInitProvider } from './lib/ModelInitContext';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <BrowserRouter>
-      <Routes>
-        <Route path="/login" element={<LoginPage />} />
-        <Route path="*" element={<Navigate to="/login" replace />} />
-      </Routes>
+      <ModelInitProvider>
+        <Routes>
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="*" element={<Navigate to="/login" replace />} />
+        </Routes>
+      </ModelInitProvider>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/frontend-react/src/pages/LoginPage.tsx
+++ b/frontend-react/src/pages/LoginPage.tsx
@@ -2,12 +2,15 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import AppShell from '@/components/layout/AppShell';
-import { useState } from 'react';
+import { useState, useContext } from 'react';
 import { Loader2 } from 'lucide-react';
 import { toast, ToastViewport } from '@/components/ui/toast';
+import LoadingOverlay from '@/components/LoadingOverlay';
+import { ModelInitContext } from '@/lib/ModelInitContext';
 
 export default function LoginPage() {
   const [loading, setLoading] = useState(false);
+  const { ready } = useContext(ModelInitContext);
 
   async function studentLogin(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -51,6 +54,7 @@ export default function LoginPage() {
   return (
     <AppShell>
       <ToastViewport />
+      <LoadingOverlay show={!ready} />
       <div className="w-full max-w-md p-6 bg-white rounded-2xl shadow-lg">
         <Tabs defaultValue="student" className="w-full space-y-6">
           <TabsList className="grid grid-cols-2">
@@ -59,10 +63,10 @@ export default function LoginPage() {
           </TabsList>
           <TabsContent value="student">
             <form onSubmit={studentLogin} className="space-y-4">
-              <Input name="username" placeholder="Gebruikersnaam" required />
-              <Input name="password" type="password" placeholder="Wachtwoord" required />
-              <Input name="teacher_id" placeholder="Klascode" />
-              <Button className="w-full" disabled={loading}>
+              <Input name="username" placeholder="Gebruikersnaam" required disabled={!ready} />
+              <Input name="password" type="password" placeholder="Wachtwoord" required disabled={!ready} />
+              <Input name="teacher_id" placeholder="Klascode" disabled={!ready} />
+              <Button className="w-full" disabled={!ready || loading}>
                 {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                 Inloggen
               </Button>
@@ -70,9 +74,9 @@ export default function LoginPage() {
           </TabsContent>
           <TabsContent value="teacher">
             <form onSubmit={teacherLogin} className="space-y-4">
-              <Input name="username" placeholder="Gebruikersnaam" required />
-              <Input name="password" type="password" placeholder="Wachtwoord" required />
-              <Button className="w-full" disabled={loading}>
+              <Input name="username" placeholder="Gebruikersnaam" required disabled={!ready} />
+              <Input name="password" type="password" placeholder="Wachtwoord" required disabled={!ready} />
+              <Button className="w-full" disabled={!ready || loading}>
                 {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                 Inloggen
               </Button>


### PR DESCRIPTION
## Summary
- create `ModelInitContext` to initialize models on app load
- add `LoadingOverlay` component for blocking UI until init finishes
- disable login form until models are ready
- wrap routing with provider in `main.tsx`
- style inputs when disabled

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68878aac9c688327a1253634c4dd26e6