### PR TITLE
Add Rubik and Nunito fonts

### DIFF
--- a/frontend-react/index.html
+++ b/frontend-react/index.html
@@ -2,6 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600&family=Rubik:wght@700&display=swap"
+      rel="stylesheet"
+    />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>

--- a/frontend-react/src/components/layout/AppShell.tsx
+++ b/frontend-react/src/components/layout/AppShell.tsx
@@ -5,7 +5,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   return (
     <div className="min-h-screen bg-slate-50 text-slate-900 flex flex-col">
       <header className="flex items-center justify-between px-6 py-4 bg-white shadow-sm">
-        <h1 className="font-title text-2xl text-primary">Leesmaatje</h1>
+        <h1 className="font-display font-bold tracking-[-0.5px] text-2xl text-primary">Leesmaatje</h1>
         <Button
           size="sm"
           variant="secondary"

--- a/frontend-react/src/components/ui/button.tsx
+++ b/frontend-react/src/components/ui/button.tsx
@@ -2,7 +2,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex items-center justify-center rounded-md text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {

--- a/frontend-react/src/components/ui/tabs.tsx
+++ b/frontend-react/src/components/ui/tabs.tsx
@@ -26,7 +26,7 @@ export function TabsTrigger({ value, className, children, ...props }: React.Butt
   return (
     <button
       className={cn(
-        'px-3 py-2 text-sm font-medium rounded-t-md border-b-2',
+        'px-3 py-2 text-sm font-semibold rounded-t-md border-b-2',
         active ? 'border-primary text-primary' : 'border-transparent text-slate-600',
         className
       )}

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -1,3 +1,15 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  :root {
+    --font-display: 'Rubik', sans-serif;
+    --font-body: 'Nunito', sans-serif;
+  }
+
+  body {
+    @apply font-sans font-normal;
+    font-family: var(--font-body);
+  }
+}

--- a/frontend-react/tailwind.config.cjs
+++ b/frontend-react/tailwind.config.cjs
@@ -8,7 +8,11 @@ module.exports = {
         success: '#A3E635',
         error: '#FB7185',
       },
-      fontFamily: { title: ['"Fredoka"', 'cursive'] },
+      fontFamily: {
+        sans: ['var(--font-body)', 'sans-serif'],
+        display: ['var(--font-display)', 'sans-serif'],
+        title: ['var(--font-display)', 'sans-serif'],
+      },
     },
   },
   plugins: [],

--- a/webapp/frontend-legacy/index.html
+++ b/webapp/frontend-legacy/index.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Leesmaatje Inloggen</title>
-  <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@400;600&family=Nunito+Sans:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/static/lucide/lucide.css">
   <link rel="stylesheet" href="/static/style.css">
 </head>

--- a/webapp/frontend-legacy/student.html
+++ b/webapp/frontend-legacy/student.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Leesmaatje Leerling</title>
-  <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@400;600&family=Nunito+Sans:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/static/lucide/lucide.css">
   <link rel="stylesheet" href="/static/style.css">
 </head>

--- a/webapp/frontend-legacy/student_results.html
+++ b/webapp/frontend-legacy/student_results.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Leerlingresultaten</title>
-  <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@400;600&family=Nunito+Sans:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/static/lucide/lucide.css">
   <link rel="stylesheet" href="/static/style.css">
 </head>

--- a/webapp/frontend-legacy/style.css
+++ b/webapp/frontend-legacy/style.css
@@ -1,12 +1,16 @@
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;600&family=Rubik:wght@700&display=swap');
+
 :root {
   --primary:#4F8CFF;
   --accent:#55C2A7;
   --bg:#F3FAFF;
   --text:#022B3A;
+  --font-display:'Rubik', sans-serif;
+  --font-body:'Nunito', sans-serif;
 }
 
 body {
-  font-family: 'Nunito Sans', sans-serif;
+  font-family: var(--font-body);
   background: var(--bg);
   color: var(--text);
   text-align: center;
@@ -15,7 +19,9 @@ body {
 }
 
 h1,h2,h3 {
-  font-family: 'Baloo 2', cursive;
+  font-family: var(--font-display);
+  font-weight:700;
+  letter-spacing:-0.5px;
   margin:0 0 1rem;
 }
 

--- a/webapp/frontend-legacy/teacher.html
+++ b/webapp/frontend-legacy/teacher.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Leesmaatje Leraar</title>
-  <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@400;600&family=Nunito+Sans:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/static/lucide/lucide.css">
   <link rel="stylesheet" href="/static/style.css">
 </head>


### PR DESCRIPTION
## Summary
- import Rubik and Nunito from Google Fonts
- define `--font-display` and `--font-body` CSS variables
- set Nunito as the default font
- apply Rubik to the main logo/header
- adjust button and tab font weight

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6887915d77548327934cde6c3ed21388