### PR TITLE
Implement dashboard flow and pages

### DIFF
--- a/frontend-react/README.md
+++ b/frontend-react/README.md
@@ -1,69 +1,28 @@
-# React + TypeScript + Vite
+# Leesmaatje React Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This SPA is built with **React 18**, **TypeScript**, **Tailwind CSS** and
+uses Zustand for state management. The app lives under `/static/react/`
+after building with Vite.
 
-Currently, two official plugins are available:
-
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      ...tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      ...tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      ...tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```
+src/
+├─ components/        reusable UI pieces
+│  ├─ layout/         app wide layout components
+│  └─ ui/             small UI primitives (button, card, ...)
+├─ pages/             route pages
+├─ lib/               stores & utilities
+└─ types.ts           shared interfaces
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+## Extending levels and themes
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+Levels and themes are currently derived from
+`webapp/backend/config.py::STORIES`. Once the backend exposes an API for
+these, update `src/lib/themeData.ts` to fetch them dynamically and adjust
+`CircularRibbon`/`LevelPage` accordingly.
 
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
+### Scripts
+
+- `npm run dev` – development server
+- `npm run lint` – ESLint
+- `npm run build` – production build

--- a/frontend-react/public/heroicons-mock.svg
+++ b/frontend-react/public/heroicons-mock.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+  <path d="M3 9h18M9 21V9" />
+</svg>

--- a/frontend-react/src/components/CircularRibbon.tsx
+++ b/frontend-react/src/components/CircularRibbon.tsx
@@ -1,0 +1,40 @@
+import LevelBadge from './LevelBadge';
+
+const LEVELS = Array.from({ length: 10 }, (_, i) => i + 1);
+
+interface Props {
+  current: number;
+  onSelect: (level: number) => void;
+}
+
+export default function CircularRibbon({ current, onSelect }: Props) {
+  const radius = 40; // percent
+  return (
+    <>
+      <div className="relative w-64 h-64 mx-auto hidden md:block">
+        {LEVELS.map((lvl, idx) => {
+          const angle = (idx / LEVELS.length) * 2 * Math.PI;
+          const x = 50 + Math.cos(angle) * radius;
+          const y = 50 + Math.sin(angle) * radius;
+          return (
+            <button
+              key={lvl}
+              style={{ left: `${x}%`, top: `${y}%` }}
+              className="absolute"
+              onClick={() => onSelect(lvl)}
+            >
+              <LevelBadge level={lvl} active={lvl === current} />
+            </button>
+          );
+        })}
+      </div>
+      <div className="flex md:hidden gap-4 overflow-x-auto px-2">
+        {LEVELS.map((lvl) => (
+          <button key={lvl} onClick={() => onSelect(lvl)} className="flex-shrink-0">
+            <LevelBadge level={lvl} active={lvl === current} />
+          </button>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/frontend-react/src/components/LevelBadge.tsx
+++ b/frontend-react/src/components/LevelBadge.tsx
@@ -1,0 +1,15 @@
+interface LevelBadgeProps {
+  level: number | string;
+  active?: boolean;
+  className?: string;
+}
+
+export default function LevelBadge({ level, active, className }: LevelBadgeProps) {
+  return (
+    <div
+      className={`flex items-center justify-center rounded-full border-2 w-12 h-12 font-bold text-sm md:w-16 md:h-16 md:text-lg ${active ? 'bg-primary text-white border-primary' : 'bg-white text-slate-700 border-slate-300'} ${className ?? ''}`}
+    >
+      {level}
+    </div>
+  );
+}

--- a/frontend-react/src/components/RequireAuth.tsx
+++ b/frontend-react/src/components/RequireAuth.tsx
@@ -1,0 +1,11 @@
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { useIsAuthenticated } from '@/lib/useAuthStore';
+
+export default function RequireAuth() {
+  const authed = useIsAuthenticated();
+  const loc = useLocation();
+  if (!authed) {
+    return <Navigate to="/" state={{ from: loc }} replace />;
+  }
+  return <Outlet />;
+}

--- a/frontend-react/src/components/ThemeCard.tsx
+++ b/frontend-react/src/components/ThemeCard.tsx
@@ -1,0 +1,18 @@
+import { Link } from 'react-router-dom';
+import { Card } from '@/components/ui/card';
+
+interface ThemeCardProps {
+  levelId: string | number;
+  theme: { id: string; title: string };
+}
+
+export default function ThemeCard({ levelId, theme }: ThemeCardProps) {
+  return (
+    <Link to={`/play/${levelId}/${theme.id}`} className="focus:outline-none focus:ring-2 focus:ring-primary rounded-xl">
+      <Card className="overflow-hidden hover:shadow-lg transition-transform hover:scale-105">
+        <img src="/heroicons-mock.svg" alt="" className="w-full h-32 object-contain bg-slate-100" />
+        <div className="p-4 font-semibold text-center">{theme.title}</div>
+      </Card>
+    </Link>
+  );
+}

--- a/frontend-react/src/components/WeeklyGoalBar.tsx
+++ b/frontend-react/src/components/WeeklyGoalBar.tsx
@@ -1,0 +1,16 @@
+import { Progress } from '@/components/ui/progress';
+
+interface Props {
+  minutes: number;
+  goal?: number;
+}
+
+export default function WeeklyGoalBar({ minutes, goal = 100 }: Props) {
+  const pct = Math.min(100, (minutes / goal) * 100);
+  return (
+    <div>
+      <Progress value={pct} />
+      <p className="text-sm text-slate-600 mt-1">{minutes} / {goal} minuten</p>
+    </div>
+  );
+}

--- a/frontend-react/src/components/layout/AppShell.tsx
+++ b/frontend-react/src/components/layout/AppShell.tsx
@@ -1,19 +1,31 @@
 import { Button } from '@/components/ui/button';
 import { LogOut } from 'lucide-react';
+import { useAuthStore } from '@/lib/useAuthStore';
 
 export default function AppShell({ children }: { children: React.ReactNode }) {
+  const { name, logout } = useAuthStore();
+  const initials = name
+    ? name
+        .split(' ')
+        .slice(0, 2)
+        .map((p) => p[0])
+        .join('')
+        .toUpperCase()
+    : '';
   return (
     <div className="min-h-screen bg-slate-50 text-slate-900 flex flex-col">
       <header className="flex items-center justify-between px-6 py-4 bg-white shadow-sm">
         <h1 className="font-display font-bold tracking-[-0.5px] text-2xl text-primary">Leesmaatje</h1>
-        <Button
-          size="sm"
-          variant="secondary"
-          onClick={() => (window.location.href = '/')}
-          className="gap-1"
-        >
-          <LogOut className="h-4 w-4" /> Uitloggen
-        </Button>
+        {name && (
+          <div className="flex items-center gap-2">
+            <div className="h-8 w-8 rounded-full bg-primary text-white flex items-center justify-center text-sm font-bold">
+              {initials}
+            </div>
+            <Button size="sm" variant="secondary" onClick={logout} className="gap-1">
+              <LogOut className="h-4 w-4" /> Uitloggen
+            </Button>
+          </div>
+        )}
       </header>
       <main className="flex-1 flex items-center justify-center p-4">{children}</main>
     </div>

--- a/frontend-react/src/components/ui/progress.tsx
+++ b/frontend-react/src/components/ui/progress.tsx
@@ -1,0 +1,13 @@
+import { cn } from '@/lib/utils';
+
+export interface ProgressProps extends React.HTMLAttributes<HTMLDivElement> {
+  value: number;
+}
+
+export function Progress({ value, className, ...props }: ProgressProps) {
+  return (
+    <div className={cn('w-full h-2 bg-slate-200 rounded-full overflow-hidden', className)} {...props}>
+      <div className="h-full bg-primary" style={{ width: `${value}%` }} />
+    </div>
+  );
+}

--- a/frontend-react/src/lib/themeData.ts
+++ b/frontend-react/src/lib/themeData.ts
@@ -1,0 +1,10 @@
+import type { LevelTheme } from '@/types';
+
+// Derived from webapp/backend/config.py::STORIES
+export const THEMES_BY_LEVEL: Record<number, LevelTheme[]> = {
+  1: [{ id: 'animals', title: 'Dieren' }],
+};
+
+export function getThemes(level: number): LevelTheme[] {
+  return THEMES_BY_LEVEL[level] ?? [];
+}

--- a/frontend-react/src/lib/useAuthStore.ts
+++ b/frontend-react/src/lib/useAuthStore.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface AuthState {
+  studentId: string | null;
+  teacherId: string | null;
+  name: string | null;
+  login: (s: { studentId: string; teacherId: string | null; name: string }) => void;
+  logout: () => void;
+}
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => ({
+      studentId: null,
+      teacherId: null,
+      name: null,
+      login: ({ studentId, teacherId, name }) =>
+        set({ studentId, teacherId, name }),
+      logout: () => set({ studentId: null, teacherId: null, name: null }),
+    }),
+    { name: 'auth' }
+  )
+);
+
+export function useIsAuthenticated() {
+  const { studentId } = useAuthStore();
+  return !!studentId;
+}

--- a/frontend-react/src/main.tsx
+++ b/frontend-react/src/main.tsx
@@ -4,14 +4,25 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import './index.css';
 import LoginPage from './pages/LoginPage';
 import { ModelInitProvider } from './lib/ModelInitContext';
+import DashboardPage from './pages/DashboardPage';
+import LevelPage from './pages/LevelPage';
+import PlayPage from './pages/PlayPage';
+import ProgressPage from './pages/ProgressPage';
+import RequireAuth from './components/RequireAuth';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <BrowserRouter>
       <ModelInitProvider>
         <Routes>
-          <Route path="/login" element={<LoginPage />} />
-          <Route path="*" element={<Navigate to="/login" replace />} />
+          <Route path="/" element={<LoginPage />} />
+          <Route element={<RequireAuth />}>
+            <Route path="/dashboard" element={<DashboardPage />} />
+            <Route path="/dashboard/level/:levelId" element={<LevelPage />} />
+            <Route path="/play/:levelId/:themeId" element={<PlayPage />} />
+            <Route path="/progress" element={<ProgressPage />} />
+          </Route>
+          <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </ModelInitProvider>
     </BrowserRouter>

--- a/frontend-react/src/pages/DashboardPage.tsx
+++ b/frontend-react/src/pages/DashboardPage.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+import AppShell from '@/components/layout/AppShell';
+import CircularRibbon from '@/components/CircularRibbon';
+import WeeklyGoalBar from '@/components/WeeklyGoalBar';
+import { Card } from '@/components/ui/card';
+import { useAuthStore } from '@/lib/useAuthStore';
+import { motion } from 'framer-motion';
+import { useNavigate } from 'react-router-dom';
+
+export default function DashboardPage() {
+  const { studentId, name } = useAuthStore();
+  const [minutes, setMinutes] = useState(0);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    async function load() {
+      if (!studentId) return;
+      const r = await fetch(`/api/student_results/${studentId}`);
+      const list = await r.json();
+      const weekAgo = Date.now() / 1000 - 7 * 24 * 3600;
+      let total = 0;
+      for (const res of list) {
+        if (res.timestamp >= weekAgo) {
+          const start = res.json_data?.start_time ?? 0;
+          const end = res.json_data?.end_time ?? start;
+          total += Math.max(0, end - start);
+        }
+      }
+      setMinutes(Math.round(total / 60));
+    }
+    load();
+  }, [studentId]);
+
+  function selectLevel(level: number) {
+    navigate(`/dashboard/level/${level}`);
+  }
+
+  return (
+    <AppShell>
+      <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="space-y-8 w-full max-w-xl">
+        <h2 className="text-center text-2xl font-title">Welkom terug, {name}!</h2>
+        <CircularRibbon current={1} onSelect={selectLevel} />
+        <Card className="p-4 space-y-2">
+          <h3 className="font-semibold">Mijn voortgang</h3>
+          <WeeklyGoalBar minutes={minutes} />
+        </Card>
+      </motion.div>
+    </AppShell>
+  );
+}

--- a/frontend-react/src/pages/LevelPage.tsx
+++ b/frontend-react/src/pages/LevelPage.tsx
@@ -1,0 +1,27 @@
+import AppShell from '@/components/layout/AppShell';
+import LevelBadge from '@/components/LevelBadge';
+import ThemeCard from '@/components/ThemeCard';
+import { useParams } from 'react-router-dom';
+import { getThemes } from '@/lib/themeData';
+import { motion } from 'framer-motion';
+
+export default function LevelPage() {
+  const { levelId } = useParams<{ levelId: string }>();
+  const lvl = Number(levelId);
+  const themes = getThemes(lvl);
+  return (
+    <AppShell>
+      <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="w-full max-w-2xl space-y-6">
+        <div className="flex items-center gap-4">
+          <LevelBadge level={lvl} active className="w-20 h-20 md:w-24 md:h-24 text-xl" />
+          <p className="text-slate-700">{/* TODO: level description */}</p>
+        </div>
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+          {themes.map((t) => (
+            <ThemeCard key={t.id} levelId={lvl} theme={t} />
+          ))}
+        </div>
+      </motion.div>
+    </AppShell>
+  );
+}

--- a/frontend-react/src/pages/LoginPage.tsx
+++ b/frontend-react/src/pages/LoginPage.tsx
@@ -7,10 +7,14 @@ import { Loader2 } from 'lucide-react';
 import { toast, ToastViewport } from '@/components/ui/toast';
 import LoadingOverlay from '@/components/LoadingOverlay';
 import { ModelInitContext } from '@/lib/ModelInitContext';
+import { useNavigate } from 'react-router-dom';
+import { useAuthStore } from '@/lib/useAuthStore';
 
 export default function LoginPage() {
   const [loading, setLoading] = useState(false);
   const { ready } = useContext(ModelInitContext);
+  const navigate = useNavigate();
+  const { login } = useAuthStore();
 
   async function studentLogin(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -20,12 +24,12 @@ export default function LoginPage() {
       const r = await fetch('/api/login_student', { method: 'POST', body: fd });
       if (!r.ok) throw new Error((await r.json()).detail);
       const j = await r.json();
-      const q = new URLSearchParams({
-        student_id: j.student_id,
-        teacher_id: j.teacher_id ?? '',
+      login({
+        studentId: j.student_id,
+        teacherId: j.teacher_id ?? null,
         name: fd.get('username') as string,
       });
-      window.location.href = `/static/select.html?${q.toString()}`;
+      navigate('/dashboard');
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       toast({ title: 'Fout', description: message, variant: 'destructive' });

--- a/frontend-react/src/pages/PlayPage.tsx
+++ b/frontend-react/src/pages/PlayPage.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+import AppShell from '@/components/layout/AppShell';
+import { Progress } from '@/components/ui/progress';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useAuthStore } from '@/lib/useAuthStore';
+import { motion } from 'framer-motion';
+import { BookOpen } from 'lucide-react';
+
+export default function PlayPage() {
+  const { levelId, themeId } = useParams<{ levelId: string; themeId: string }>();
+  const [progress, setProgress] = useState(0);
+  const navigate = useNavigate();
+  const { studentId, teacherId, name } = useAuthStore();
+
+  useEffect(() => {
+    const ev = new EventSource(`/api/start_story?theme=${themeId}&level=${levelId}`);
+    const data: unknown[] = [];
+    ev.addEventListener('progress', (e) => {
+      setProgress(parseFloat((e as MessageEvent).data) * 100);
+    });
+    ev.addEventListener('sentence', (e) => {
+      data.push({ type: 'sentence', ...(JSON.parse((e as MessageEvent).data)) });
+    });
+    ev.addEventListener('direction', (e) => {
+      data.push({ type: 'direction', ...(JSON.parse((e as MessageEvent).data)) });
+    });
+    ev.addEventListener('complete', () => {
+      ev.close();
+      localStorage.setItem('story_data', JSON.stringify(data));
+      localStorage.setItem('theme', String(themeId));
+      localStorage.setItem('level', String(levelId));
+      const q = new URLSearchParams({
+        student_id: studentId ?? '',
+        teacher_id: teacherId ?? '',
+        name: name ?? '',
+      });
+      window.location.href = `/static/story.html?${q.toString()}`;
+    });
+    return () => {
+      ev.close();
+    };
+  }, [levelId, themeId, studentId, teacherId, name, navigate]);
+
+  return (
+    <AppShell>
+      <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="space-y-6 w-full max-w-md text-center">
+        <h2 className="font-title text-xl">Voorbereiden…</h2>
+        <div className="flex justify-center">
+          <motion.div animate={{ rotate: 360 }} transition={{ repeat: Infinity, duration: 2, ease: 'linear' }}>
+            <BookOpen className="h-12 w-12 text-primary" />
+          </motion.div>
+        </div>
+        <Progress value={progress} />
+        <p className="text-sm text-slate-600">{Math.round(progress)}%</p>
+      </motion.div>
+    </AppShell>
+  );
+}

--- a/frontend-react/src/pages/ProgressPage.tsx
+++ b/frontend-react/src/pages/ProgressPage.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react';
+import AppShell from '@/components/layout/AppShell';
+import { useAuthStore } from '@/lib/useAuthStore';
+import { motion } from 'framer-motion';
+import { Check, XCircle } from 'lucide-react';
+
+interface ResultItem {
+  id: string;
+  sentence: string;
+  timestamp: number;
+  json_data: { start_time?: number; end_time?: number; correct?: boolean };
+}
+
+export default function ProgressPage() {
+  const { studentId } = useAuthStore();
+  const [results, setResults] = useState<ResultItem[]>([]);
+  const [minutes, setMinutes] = useState(0);
+
+  useEffect(() => {
+    async function load() {
+      if (!studentId) return;
+      const r = await fetch(`/api/student_results/${studentId}`);
+      const list: ResultItem[] = await r.json();
+      setResults(list);
+      const monthStart = new Date();
+      monthStart.setDate(1);
+      const startTs = monthStart.getTime() / 1000;
+      let total = 0;
+      for (const res of list) {
+        if (res.timestamp >= startTs) {
+          const s = res.json_data?.start_time ?? 0;
+          const e = res.json_data?.end_time ?? s;
+          total += Math.max(0, e - s);
+        }
+      }
+      setMinutes(Math.round(total / 60));
+    }
+    load();
+  }, [studentId]);
+
+  const recent = results.slice(0, 5);
+
+  return (
+    <AppShell>
+      <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="w-full max-w-xl space-y-6">
+        <h2 className="font-title text-xl">Resultaten deze maand: {minutes} min</h2>
+        {recent.length === 0 ? (
+          <p className="text-center text-slate-600">Nog geen resultaten.</p>
+        ) : (
+          <ul className="space-y-2">
+            {recent.map((r) => (
+              <li key={r.id} className="flex items-center justify-between rounded-md bg-white p-2 shadow">
+                <span>{r.sentence}</span>
+                <span className="text-slate-500 text-sm">{new Date(r.timestamp * 1000).toLocaleDateString()}</span>
+                {r.json_data?.correct ? (
+                  <Check className="text-success h-5 w-5" />
+                ) : (
+                  <XCircle className="text-error h-5 w-5" />
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </motion.div>
+    </AppShell>
+  );
+}

--- a/frontend-react/src/types.ts
+++ b/frontend-react/src/types.ts
@@ -1,0 +1,4 @@
+export interface LevelTheme {
+  id: string;
+  title: string;
+}


### PR DESCRIPTION
## Summary
- manage auth state with zustand and persist to localStorage
- implement protected routes and new pages (dashboard, level, play loader, progress)
- add UI components: circular level ribbon, badges, theme cards, weekly goal bar
- extend AppShell with avatar and logout when authenticated
- update routing and login flow
- document app structure in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6887affc89348327ac68d4ffe8e948b1