### PR TITLE
Add React sentence play page

### DIFF
--- a/frontend-react/src/features/play/useRecorder.ts
+++ b/frontend-react/src/features/play/useRecorder.ts
@@ -1,0 +1,176 @@
+import { useState, useRef, useCallback } from 'react';
+
+function encodeWav(samples: Int16Array, sampleRate: number) {
+  const buffer = new ArrayBuffer(44 + samples.length * 2);
+  const view = new DataView(buffer);
+  const writeStr = (off: number, str: string) => {
+    for (let i = 0; i < str.length; i++) view.setUint8(off + i, str.charCodeAt(i));
+  };
+  writeStr(0, 'RIFF');
+  view.setUint32(4, 36 + samples.length * 2, true);
+  writeStr(8, 'WAVEfmt ');
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * 2, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  writeStr(36, 'data');
+  view.setUint32(40, samples.length * 2, true);
+  for (let i = 0; i < samples.length; i++) view.setInt16(44 + i * 2, samples[i], true);
+  return new Blob([view], { type: 'audio/wav' });
+}
+
+export interface RecorderResult {
+  correct?: boolean;
+  feedback_audio: string;
+}
+
+export function useRecorder(
+  sentence: string | null,
+  teacherId: string | null,
+  studentId: string | null
+) {
+  const [state, setState] = useState<'idle' | 'recording' | 'analysing'>('idle');
+  const [playbackUrl, setPlaybackUrl] = useState<string | null>(null);
+  const [result, setResult] = useState<RecorderResult | null>(null);
+
+  const audioCtx = useRef<AudioContext | null>(null);
+  const processor = useRef<ScriptProcessorNode | null>(null);
+  const analyser = useRef<AnalyserNode | null>(null);
+  const dataArray = useRef<Uint8Array | null>(null);
+  const stream = useRef<MediaStream | null>(null);
+  const startPromise = useRef<Promise<void> | null>(null);
+  const sessionId = useRef<string | null>(null);
+  const fillerAudio = useRef<string | null>(null);
+  const delaySeconds = useRef(0);
+  const pendingChunks = useRef<Blob[]>([]);
+  const chunks = useRef<Int16Array[]>([]);
+
+
+  const start = useCallback(async () => {
+    if (!sentence) return;
+    stream.current = await navigator.mediaDevices.getUserMedia({ audio: true });
+    audioCtx.current = new AudioContext();
+    const fd = new FormData();
+    fd.append('sentence', sentence);
+    fd.append('sample_rate', String(audioCtx.current.sampleRate));
+    if (teacherId) fd.append('teacher_id', teacherId);
+    if (studentId) fd.append('student_id', studentId);
+
+    startPromise.current = fetch('/api/realtime/start', { method: 'POST', body: fd })
+      .then(async (r) => {
+        const j = await r.json();
+        if (!r.ok) throw new Error(j.detail);
+        sessionId.current = j.session_id;
+        fillerAudio.current = j.filler_audio;
+        delaySeconds.current = j.delay_seconds;
+        for (const b of pendingChunks.current) {
+          const f = new FormData();
+          f.append('file', b, 'chunk.pcm');
+          fetch('/api/realtime/chunk/' + sessionId.current, { method: 'POST', body: f });
+        }
+        pendingChunks.current = [];
+      })
+      .catch((err) => {
+        console.error(err);
+        setState('idle');
+      })
+      .finally(() => {
+        startPromise.current = null;
+      });
+
+    const source = audioCtx.current.createMediaStreamSource(stream.current);
+    analyser.current = audioCtx.current.createAnalyser();
+    analyser.current.fftSize = 512;
+    dataArray.current = new Uint8Array(analyser.current.fftSize);
+    processor.current = audioCtx.current.createScriptProcessor(4096, 1, 1);
+    source.connect(analyser.current);
+    analyser.current.connect(processor.current);
+    processor.current.connect(audioCtx.current.destination);
+    processor.current.onaudioprocess = (e) => {
+      if (state !== 'recording') return;
+      const buf = e.inputBuffer.getChannelData(0);
+      const pcm = new Int16Array(buf.length);
+      for (let i = 0; i < buf.length; i++) {
+        const sample = Math.max(-1, Math.min(1, buf[i]));
+        pcm[i] = sample * 32767;
+      }
+      chunks.current.push(pcm);
+      const blob = new Blob([pcm], { type: 'application/octet-stream' });
+      if (sessionId.current) {
+        const f = new FormData();
+        f.append('file', blob, 'chunk.pcm');
+        fetch('/api/realtime/chunk/' + sessionId.current, { method: 'POST', body: f });
+      } else {
+        pendingChunks.current.push(blob);
+      }
+    };
+    chunks.current = [];
+    setState('recording');
+  }, [sentence, teacherId, studentId, state]);
+
+  const stop = useCallback(async () => {
+    if (state !== 'recording') return;
+    setState('analysing');
+    processor.current?.disconnect();
+    stream.current?.getTracks().forEach((t) => t.stop());
+    if (startPromise.current) {
+      try {
+        await startPromise.current;
+      } catch {
+        return;
+      }
+    }
+    const stopPromise = fetch('/api/realtime/stop/' + sessionId.current, { method: 'POST' }).then(
+      async (r) => {
+        const j = await r.json();
+        if (!r.ok) throw new Error(j.detail);
+        return j as RecorderResult;
+      }
+    );
+    sessionId.current = null;
+    setTimeout(async () => {
+      if (fillerAudio.current) new Audio('/api/audio/' + fillerAudio.current).play();
+      let data: RecorderResult;
+      try {
+        data = await stopPromise;
+      } catch (err) {
+        console.error(err);
+        setState('idle');
+        return;
+      }
+      const total = chunks.current.reduce((n, c) => n + c.length, 0);
+      const flat = new Int16Array(total);
+      let pos = 0;
+      for (const c of chunks.current) {
+        flat.set(c, pos);
+        pos += c.length;
+      }
+      const wav = encodeWav(flat, audioCtx.current!.sampleRate);
+      setPlaybackUrl(URL.createObjectURL(wav));
+      setResult(data);
+      setState('idle');
+    }, delaySeconds.current * 1000);
+  }, [state]);
+
+  const level = useCallback(() => {
+    if (!analyser.current || !dataArray.current) return 0;
+    analyser.current.getByteTimeDomainData(dataArray.current);
+    let sum = 0;
+    for (let i = 0; i < dataArray.current.length; i++) {
+      const val = dataArray.current[i] - 128;
+      sum += val * val;
+    }
+    const rms = Math.sqrt(sum / dataArray.current.length) / 128;
+    return rms;
+  }, []);
+
+  const reset = useCallback(() => {
+    setPlaybackUrl(null);
+    setResult(null);
+  }, []);
+
+  return { state, start, stop, playbackUrl, result, level, reset };
+}

--- a/frontend-react/src/features/play/useStoryData.ts
+++ b/frontend-react/src/features/play/useStoryData.ts
@@ -1,0 +1,46 @@
+import { useEffect } from 'react';
+import { create } from 'zustand';
+
+export interface StorySentence {
+  text: string;
+  audio: string;
+  words: string[];
+}
+
+interface StoryState {
+  stories: Record<string, StorySentence[]>;
+  setStory: (key: string, story: StorySentence[]) => void;
+}
+
+const useStoryStore = create<StoryState>((set) => ({
+  stories: {},
+  setStory: (key, story) =>
+    set((s) => ({ stories: { ...s.stories, [key]: story } })),
+}));
+
+export function useStoryData(levelId?: string, themeId?: string) {
+  const key = `${levelId}|${themeId}`;
+  const story = useStoryStore((s) =>
+    levelId && themeId ? s.stories[key] : undefined
+  );
+  const setStory = useStoryStore((s) => s.setStory);
+
+  useEffect(() => {
+    if (!levelId || !themeId || story) return;
+    const ev = new EventSource(
+      `/api/start_story?theme=${themeId}&level=${levelId}`
+    );
+    const items: StorySentence[] = [];
+    ev.addEventListener('sentence', (e) => {
+      const j = JSON.parse((e as MessageEvent).data);
+      items.push({ text: j.text, audio: j.audio, words: j.words });
+    });
+    ev.addEventListener('complete', () => {
+      setStory(key, items);
+      ev.close();
+    });
+    return () => ev.close();
+  }, [levelId, themeId, story, key, setStory]);
+
+  return story;
+}

--- a/frontend-react/src/main.tsx
+++ b/frontend-react/src/main.tsx
@@ -19,7 +19,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
           <Route element={<RequireAuth />}>
             <Route path="/dashboard" element={<DashboardPage />} />
             <Route path="/dashboard/level/:levelId" element={<LevelPage />} />
-            <Route path="/play/:levelId/:themeId" element={<PlayPage />} />
+            <Route path="/play/:levelId/:themeId/:idx?" element={<PlayPage />} />
             <Route path="/progress" element={<ProgressPage />} />
           </Route>
           <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend-react/src/pages/PlayPage.tsx
+++ b/frontend-react/src/pages/PlayPage.tsx
@@ -1,58 +1,191 @@
-import { useEffect, useState } from 'react';
+import { useState, useEffect } from 'react';
 import AppShell from '@/components/layout/AppShell';
 import { Progress } from '@/components/ui/progress';
-import { useParams, useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { toast, ToastViewport } from '@/components/ui/toast';
+import { useParams } from 'react-router-dom';
 import { useAuthStore } from '@/lib/useAuthStore';
-import { motion } from 'framer-motion';
-import { BookOpen } from 'lucide-react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { Volume2, ChevronsLeft, ChevronsRight, Mic, Loader2, RefreshCw } from 'lucide-react';
+import { useStoryData } from '@/features/play/useStoryData';
+import { useRecorder } from '@/features/play/useRecorder';
 
 export default function PlayPage() {
-  const { levelId, themeId } = useParams<{ levelId: string; themeId: string }>();
-  const [progress, setProgress] = useState(0);
-  const navigate = useNavigate();
-  const { studentId, teacherId, name } = useAuthStore();
+  const { levelId, themeId, idx } = useParams<{
+    levelId: string;
+    themeId: string;
+    idx?: string;
+  }>();
+  const story = useStoryData(levelId, themeId);
+  const [index, setIndex] = useState(() => Number(idx ?? 0));
+  const { studentId, teacherId } = useAuthStore();
+  const current = story ? story[index] : null;
+  const { state, start, stop, playbackUrl, result, level, reset } = useRecorder(
+    current?.text ?? null,
+    teacherId,
+    studentId
+  );
+  const [micLevel, setMicLevel] = useState(0);
 
   useEffect(() => {
-    const ev = new EventSource(`/api/start_story?theme=${themeId}&level=${levelId}`);
-    const data: unknown[] = [];
-    ev.addEventListener('progress', (e) => {
-      setProgress(parseFloat((e as MessageEvent).data) * 100);
-    });
-    ev.addEventListener('sentence', (e) => {
-      data.push({ type: 'sentence', ...(JSON.parse((e as MessageEvent).data)) });
-    });
-    ev.addEventListener('direction', (e) => {
-      data.push({ type: 'direction', ...(JSON.parse((e as MessageEvent).data)) });
-    });
-    ev.addEventListener('complete', () => {
-      ev.close();
-      localStorage.setItem('story_data', JSON.stringify(data));
-      localStorage.setItem('theme', String(themeId));
-      localStorage.setItem('level', String(levelId));
-      const q = new URLSearchParams({
-        student_id: studentId ?? '',
-        teacher_id: teacherId ?? '',
-        name: name ?? '',
+    if (result) {
+      toast({
+        title: result.correct ? 'Goed gedaan!' : 'Probeer opnieuw',
+        description: '',
+        variant: result.correct ? 'default' : 'destructive',
       });
-      window.location.href = `/static/story.html?${q.toString()}`;
-    });
-    return () => {
-      ev.close();
-    };
-  }, [levelId, themeId, studentId, teacherId, name, navigate]);
+    }
+  }, [result]);
+
+  useEffect(() => {
+    let raf: number;
+    if (state === 'recording') {
+      const draw = () => {
+        setMicLevel(level());
+        raf = requestAnimationFrame(draw);
+      };
+      draw();
+    }
+    return () => cancelAnimationFrame(raf);
+  }, [state, level]);
+
+  useEffect(() => {
+    if (studentId && themeId && levelId) {
+      localStorage.setItem(
+        `${studentId}|${themeId}|${levelId}`,
+        String(index)
+      );
+    }
+  }, [index, studentId, themeId, levelId]);
+
+  if (!story || !current) {
+    return (
+      <AppShell>
+        <div className="space-y-6 w-full max-w-md text-center">
+          <h2 className="font-title text-xl">Voorbereiden…</h2>
+          <div className="flex justify-center">
+            <motion.div
+              animate={{ rotate: 360 }}
+              transition={{ repeat: Infinity, duration: 2, ease: 'linear' }}
+            >
+              <Loader2 className="h-12 w-12 text-primary" />
+            </motion.div>
+          </div>
+          <Progress value={0} />
+        </div>
+      </AppShell>
+    );
+  }
+
+  const total = story.length;
+  const progress = ((index + 1) / total) * 100;
+
+  function playSentence() {
+    new Audio('/api/audio/' + current!.audio).play();
+  }
+
+  function playWord(i: number) {
+    const audio = current!.words[i];
+    if (audio) new Audio('/api/audio/' + audio).play();
+  }
+
+  const canPrev = index > 0;
+  const canNext = index < total - 1;
 
   return (
     <AppShell>
-      <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="space-y-6 w-full max-w-md text-center">
-        <h2 className="font-title text-xl">Voorbereiden…</h2>
-        <div className="flex justify-center">
-          <motion.div animate={{ rotate: 360 }} transition={{ repeat: Infinity, duration: 2, ease: 'linear' }}>
-            <BookOpen className="h-12 w-12 text-primary" />
-          </motion.div>
+      <ToastViewport />
+      <div className="flex flex-col items-center w-full min-h-screen justify-center bg-gradient-to-b from-[#ecf7ff] to-[#f5fbff] p-4">
+        <div className="w-full max-w-3xl space-y-6">
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={index}
+              initial={{ x: 100, opacity: 0 }}
+              animate={{ x: 0, opacity: 1 }}
+              exit={{ x: -100, opacity: 0 }}
+              transition={{ duration: 0.3 }}
+            >
+              <Card className="p-6 text-center shadow-xl space-y-4">
+                <button
+                  onClick={playSentence}
+                  className="ml-auto block text-slate-600 hover:text-primary"
+                >
+                  <Volume2 className="h-6 w-6" />
+                </button>
+                <p className="text-xl flex flex-wrap justify-center gap-1">
+                  {current.text.split(' ').map((w, i) => {
+                    const audio = current.words[i];
+                    return audio ? (
+                      <button
+                        key={i}
+                        onClick={() => playWord(i)}
+                        className="hover:bg-primary/20 rounded px-1"
+                      >
+                        {w}
+                      </button>
+                    ) : (
+                      <span key={i}>{w}</span>
+                    );
+                  })}
+                </p>
+              </Card>
+            </motion.div>
+          </AnimatePresence>
+          <Progress value={progress} />
+          <div className="flex flex-col items-center gap-4">
+            <div className="relative" style={{
+                width: '40vh',
+                height: '40vh',
+                maxWidth: '300px',
+                maxHeight: '300px',
+                minWidth: '150px',
+                minHeight: '150px',
+              }}>
+              <div
+                className="absolute inset-0 rounded-full border-4 border-primary/50"
+                style={{ transform: `scale(${1 + micLevel})` }}
+              />
+              <button
+                onClick={state === 'recording' ? stop : start}
+                className={`rounded-full bg-primary text-white flex items-center justify-center w-full h-full ${
+                  state === 'recording' ? 'animate-pulse' : ''
+                }`}
+              >
+                {state === 'analysing' ? (
+                  <Loader2 className="h-12 w-12 animate-spin" />
+                ) : (
+                  <Mic className="h-12 w-12" />
+                )}
+              </button>
+            </div>
+            {playbackUrl && (
+              <audio controls src={playbackUrl} className="w-full" />
+            )}
+            {playbackUrl && (
+              <Button
+                variant="secondary"
+                onClick={() => {
+                  reset();
+                }}
+              >
+                <RefreshCw className="h-4 w-4 mr-1" /> Opnieuw
+              </Button>
+            )}
+          </div>
+          <div className="flex items-center justify-between text-lg">
+            <Button variant="secondary" onClick={() => setIndex(index - 1)} disabled={!canPrev}>
+              <ChevronsLeft className="h-5 w-5" />
+            </Button>
+            <span>
+              {index + 1} / {total}
+            </span>
+            <Button variant="secondary" onClick={() => setIndex(index + 1)} disabled={!canNext}>
+              <ChevronsRight className="h-5 w-5" />
+            </Button>
+          </div>
         </div>
-        <Progress value={progress} />
-        <p className="text-sm text-slate-600">{Math.round(progress)}%</p>
-      </motion.div>
+      </div>
     </AppShell>
   );
 }


### PR DESCRIPTION
## Summary
- implement new `/play` screen with sentence card, recorder, and nav controls
- store story data in Zustand via `useStoryData`
- add recorder logic in `useRecorder`
- support optional index param in router

## Testing
- `npm run lint`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68886f96c85c8327b1f921d013f08143