### PR TITLE
Fix microphone button overlay

### DIFF
--- a/frontend-react/src/components/story/MicButton.tsx
+++ b/frontend-react/src/components/story/MicButton.tsx
@@ -32,7 +32,7 @@ export default function MicButton({ onClick, recording, waveLevel }: Props) {
         width={150}
         height={150}
         aria-hidden="true"
-        className={recording ? 'absolute inset-0' : 'hidden'}
+        className={recording ? 'absolute inset-0 pointer-events-none' : 'hidden'}
       />
       <button
         onClick={onClick}


### PR DESCRIPTION
## Summary
- disable pointer events on canvas overlay so the user can stop recording

## Testing
- `npm test --silent` in `frontend-react`

------
https://chatgpt.com/codex/tasks/task_e_688888067af8832782cf822aa81b0c93