### PR TITLE
Add feedback message UI

### DIFF
--- a/frontend-react/src/components/story/FeedbackMessage.tsx
+++ b/frontend-react/src/components/story/FeedbackMessage.tsx
@@ -1,0 +1,19 @@
+import { motion } from 'framer-motion';
+
+interface Props {
+  text: string;
+  positive: boolean;
+}
+
+export default function FeedbackMessage({ text, positive }: Props) {
+  return (
+    <motion.p
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      role="status"
+      aria-live="polite"
+      className={`mt-2 font-semibold ${positive ? 'text-green-600' : 'text-red-600'}`}
+      dangerouslySetInnerHTML={{ __html: text }}
+    />
+  );
+}

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -13,3 +13,9 @@
     font-family: var(--font-body);
   }
 }
+
+@layer components {
+  .highlight {
+    @apply font-bold bg-yellow-100 px-1 rounded;
+  }
+}

--- a/frontend-react/src/pages/StoryPage.tsx
+++ b/frontend-react/src/pages/StoryPage.tsx
@@ -6,6 +6,7 @@ import ProgressBar from '@/components/story/ProgressBar';
 import MicButton from '@/components/story/MicButton';
 import NavButton from '@/components/story/NavButton';
 import FeedbackToast from '@/components/story/FeedbackToast';
+import FeedbackMessage from '@/components/story/FeedbackMessage';
 import DirectionsChooser from '@/components/story/DirectionsChooser';
 import { useRecorder } from '@/hooks/useRecorder';
 import { useStory } from '@/hooks/useStory';
@@ -40,6 +41,12 @@ export default function StoryPage() {
     <AppShell>
       <div className="w-full max-w-xl bg-gradient-to-b from-primary/5 to-primary/0 p-6 rounded-2xl">
         <SentenceCard item={item?.type === 'sentence' ? item : null} />
+        {rec.lastFeedback && (
+          <FeedbackMessage
+            text={rec.lastFeedback.feedback_text.replace(/\*\*(.*?)\*\*/g, '<strong class="highlight">$1</strong>')}
+            positive={rec.lastFeedback.correct !== false}
+          />
+        )}
         {directionOpts && (
           <DirectionsChooser
             options={directionOpts}


### PR DESCRIPTION
## Summary
- show recording feedback under the sentence during playback
- tweak global styles to support highlighted text

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6888b95a05d8832789f9c26683dc1d84