### PR TITLE
Fix feedback audio playback

### DIFF
--- a/frontend-react/src/hooks/useRecorder.ts
+++ b/frontend-react/src/hooks/useRecorder.ts
@@ -171,6 +171,9 @@ export function useRecorder(studentId: string | null, teacherId: number | null) 
     recorded.current = [];
     fillerAudio.current = null;
     setLastFeedback(data);
+    if (data.feedback_audio) {
+      new Audio('/api/audio/' + data.feedback_audio).play();
+    }
   }, [isRecording]);
 
   const replayFeedback = useCallback(() => {

--- a/frontend-react/src/pages/StoryPage.tsx
+++ b/frontend-react/src/pages/StoryPage.tsx
@@ -73,7 +73,13 @@ export default function StoryPage() {
         {rec.lastFeedback && (
           <FeedbackToast
             text={rec.lastFeedback.feedback_text.replace(/\*\*(.*?)\*\*/g, '<strong class="highlight">$1</strong>')}
-            positive={rec.lastFeedback.correct !== false}
+            positive={
+              rec.lastFeedback.correct !== undefined
+                ? rec.lastFeedback.correct
+                : !/opnieuw|niet gehoord|again|wrong/i.test(
+                    rec.lastFeedback.feedback_text,
+                  )
+            }
             onReplay={rec.replayFeedback}
           />
         )}


### PR DESCRIPTION
## Summary
- ensure feedback audio plays back after each recording
- compute positive/negative feedback like the legacy logic

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6888cf1e7e0c8327ac12e66012820326