### PR TITLE
Fix recorder to use AudioWorklet

### DIFF
--- a/frontend-react/public/recorder-worklet.js
+++ b/frontend-react/public/recorder-worklet.js
@@ -1,0 +1,11 @@
+class RecorderProcessor extends AudioWorkletProcessor {
+  process(inputs) {
+    const input = inputs[0];
+    if (input && input[0]) {
+      this.port.postMessage(input[0]);
+    }
+    return true;
+  }
+}
+
+registerProcessor('recorder-processor', RecorderProcessor);


### PR DESCRIPTION
## Summary
- switch recorder hook to AudioWorkletNode
- add `recorder-worklet.js` for audio capture

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6888d2c17db88327ae0bd2e3039c6982