### PR TITLE
Fix persistent feedback style

### DIFF
--- a/frontend-react/src/components/story/FeedbackToast.tsx
+++ b/frontend-react/src/components/story/FeedbackToast.tsx
@@ -11,7 +11,9 @@ export default function FeedbackToast({ text, positive, onReplay }: Props) {
     <div
       role="status"
       aria-live="polite"
-      className={`mt-4 flex items-center justify-between p-4 rounded-xl shadow ${positive ? 'bg-green-100' : 'bg-red-100'}`}
+      className={`mt-4 flex items-center justify-between p-4 rounded-xl shadow ${
+        positive ? 'bg-green-100 text-green-900' : 'bg-red-100 text-red-900'
+      }`}
     >
       <p dangerouslySetInnerHTML={{ __html: text }} />
       <button

--- a/frontend-react/src/hooks/useRecorder.ts
+++ b/frontend-react/src/hooks/useRecorder.ts
@@ -115,7 +115,7 @@ export function useRecorder(studentId: string | null, teacherId: number | null) 
     setWaveLevel(0);
     if (playbackUrl) URL.revokeObjectURL(playbackUrl);
     setPlaybackUrl(null);
-    setLastFeedback(null);
+    // Keep showing previous feedback while recording
     visualize();
   }, [isRecording, playbackUrl, studentId, teacherId, visualize]);
 

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -13,3 +13,9 @@
     font-family: var(--font-body);
   }
 }
+
+@layer components {
+  .highlight {
+    @apply font-bold bg-yellow-200 rounded px-1;
+  }
+}


### PR DESCRIPTION
## Summary
- keep feedback visible while recording
- show feedback text in green for correct and red for incorrect
- add `highlight` styling for emphasized words

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6889e3e4541083279764b4ef8ad14bc7