### PR TITLE
Highlight spoken mistakes in React app

### DIFF
--- a/frontend-react/src/components/story/SentenceCard.tsx
+++ b/frontend-react/src/components/story/SentenceCard.tsx
@@ -1,21 +1,34 @@
 import Word from './Word';
 import { Volume2 } from 'lucide-react';
 import type { StoryItem } from '@/hooks/useStory';
+import type { FeedbackError } from '@/hooks/useRecorder';
 
 interface Props {
   item: StoryItem | null;
+  errors?: FeedbackError[];
 }
 
-export default function SentenceCard({ item }: Props) {
+export default function SentenceCard({ item, errors }: Props) {
   if (!item || item.type !== 'sentence') return <p className="min-h-[4rem]" />;
   function playSentence() {
     if (!item) return;
     new Audio('/api/audio/' + item.audio).play();
   }
+  const wrongWords = new Set<string>();
+  if (Array.isArray(errors)) {
+    for (const err of errors) {
+      const w = err.expected_word ?? err.word;
+      if (typeof w === 'string') wrongWords.add(w.toLowerCase());
+    }
+  }
   return (
     <p className="text-2xl md:text-3xl font-semibold">
       {item.text.split(' ').map((w, i) => (
-        <Word key={i} audio={item.words ? item.words[i] : undefined}>
+        <Word
+          key={i}
+          audio={item.words ? item.words[i] : undefined}
+          wrong={wrongWords.has(w.toLowerCase())}
+        >
           {w}
         </Word>
       ))}

--- a/frontend-react/src/components/story/Word.tsx
+++ b/frontend-react/src/components/story/Word.tsx
@@ -1,15 +1,18 @@
 interface Props {
   children: string;
   audio?: string;
+  wrong?: boolean;
 }
 
-export default function Word({ children, audio }: Props) {
+export default function Word({ children, audio, wrong }: Props) {
   function play() {
     if (audio) new Audio('/api/audio/' + audio).play();
   }
   return (
     <span
-      className="cursor-pointer hover:text-primary"
+      className={
+        'cursor-pointer hover:text-primary' + (wrong ? ' wrong shake' : '')
+      }
       onClick={play}
     >
       {children}{' '}

--- a/frontend-react/src/hooks/useRecorder.ts
+++ b/frontend-react/src/hooks/useRecorder.ts
@@ -2,11 +2,16 @@ import { useCallback, useRef, useState } from 'react';
 import { encodeWav } from '@/lib/wav';
 import { toast } from '@/components/ui/toast';
 
+export interface FeedbackError {
+  expected_word?: string;
+  word?: string;
+}
+
 interface FeedbackData {
   feedback_text: string;
   feedback_audio: string;
   correct?: boolean;
-  errors?: unknown[];
+  errors?: FeedbackError[];
 }
 
 export function useRecorder(studentId: string | null, teacherId: number | null) {

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -18,4 +18,16 @@
   .highlight {
     @apply font-bold bg-yellow-200 rounded px-1;
   }
+  .wrong {
+    @apply bg-red-200 text-red-900 rounded px-1;
+  }
+  @keyframes shake {
+    0% { transform: translateX(0); }
+    25% { transform: translateX(-0.25rem); }
+    75% { transform: translateX(0.25rem); }
+    100% { transform: translateX(0); }
+  }
+  .shake {
+    animation: shake 90ms ease-in-out;
+  }
 }

--- a/frontend-react/src/pages/StoryPage.tsx
+++ b/frontend-react/src/pages/StoryPage.tsx
@@ -39,7 +39,10 @@ export default function StoryPage() {
   return (
     <AppShell>
       <div className="w-full max-w-xl bg-gradient-to-b from-primary/5 to-primary/0 p-6 rounded-2xl">
-        <SentenceCard item={item?.type === 'sentence' ? item : null} />
+        <SentenceCard
+          item={item?.type === 'sentence' ? item : null}
+          errors={rec.lastFeedback?.errors}
+        />
         {directionOpts && (
           <DirectionsChooser
             options={directionOpts}


### PR DESCRIPTION
## Summary
- persist feedback and show wrong words on the sentence
- color incorrect words red and animate them slightly
- expose `FeedbackError` type in recorder hook
- wire error data to `SentenceCard`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6889ea3fed9883279aad16ac6689b5d2