### PR TITLE
Fix wavfile closing order

### DIFF
--- a/webapp/backend/realtime.py
+++ b/webapp/backend/realtime.py
@@ -101,6 +101,11 @@ class RealtimeSession:
         # Allow final chunks to arrive before signaling end-of-stream
         time.sleep(0.5)
         self.audio_q.put(None)
+        # Close the WAV file before any offline processing so that
+        # the written data has a proper header and can be read back
+        # by ``soundfile``.
+        self.wavefile.close()
+
         if self.phon_thread.realtime:
             self.phon_thread.stop()
             self.phon_thread.join()
@@ -122,8 +127,6 @@ class RealtimeSession:
             self.azure_plain.stop()
         else:
             self.azure_plain.process_file(self.wav_path)
-
-        self.wavefile.close()
         flush_audio_queue(self.audio_q)
 
         self.results["end_time"] = time.time()


### PR DESCRIPTION
## Summary
- close realtime wav file before processing offline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a186483008327949c01d1ad66997f