### PR TITLE
Fix build by adding audio worklet types

### DIFF
--- a/frontend-react/package-lock.json
+++ b/frontend-react/package-lock.json
@@ -28,6 +28,7 @@
         "@types/node": "^24.1.0",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
+        "@types/web": "^0.0.256",
         "@vitejs/plugin-react": "^4.6.0",
         "autoprefixer": "^10.4.21",
         "eslint": "^9.30.1",
@@ -2554,6 +2555,13 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/web": {
+      "version": "0.0.256",
+      "resolved": "https://registry.npmjs.org/@types/web/-/web-0.0.256.tgz",
+      "integrity": "sha512-UUTchArLLQlghh2tf88fJzFktJdO3O3AzPPxyML1BPkccWOZCwetAfKrF3TsqRI4h5/d6S+OhMcloh1YzXab5w==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",

--- a/frontend-react/package.json
+++ b/frontend-react/package.json
@@ -27,6 +27,7 @@
     "@types/node": "^24.1.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
+    "@types/web": "^0.0.256",
     "@vitejs/plugin-react": "^4.6.0",
     "autoprefixer": "^10.4.21",
     "@testing-library/react": "^16.3.0",

--- a/frontend-react/src/audio-worklet.d.ts
+++ b/frontend-react/src/audio-worklet.d.ts
@@ -1,0 +1,16 @@
+/// <reference lib="webworker" />
+
+declare abstract class AudioWorkletProcessor {
+  readonly port: MessagePort;
+  constructor(options?: unknown);
+  abstract process(
+    inputs: Float32Array[][],
+    outputs: Float32Array[][],
+    parameters: Record<string, Float32Array>
+  ): boolean;
+}
+
+declare function registerProcessor(
+  name: string,
+  processorCtor: typeof AudioWorkletProcessor
+): void;

--- a/frontend-react/src/lib/recorder-processor.ts
+++ b/frontend-react/src/lib/recorder-processor.ts
@@ -1,3 +1,5 @@
+/// <reference lib="webworker" />
+
 class RecorderProcessor extends AudioWorkletProcessor {
   process(inputs: Float32Array[][]) {
     const input = inputs[0];


### PR DESCRIPTION
## Summary
- add minimal `AudioWorkletProcessor` typings
- reference webworker types for the recorder processor
- install `@types/web` so `tsc` recognizes AudioWorklet classes

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a215ac1fc83279f8267cccf6db3c6