### PR TITLE
Fix wav2vec2 results missing

### DIFF
--- a/FASE2_recorder_pipeline.py
+++ b/FASE2_recorder_pipeline.py
@@ -199,6 +199,14 @@ class RecorderPipeline:
             t_stop_press = time.perf_counter()
             recorder.stop()
             time.sleep(0.1)   # let callbacks flush
+            # Ensure all Wav2Vec2 threads see the end-of-stream sentinel
+            extra_sentinels = (
+                int(extractor_phonemes.realtime)
+                + int(extractor_text.realtime)
+                - 1
+            )
+            for _ in range(max(extra_sentinels, 0)):
+                recorder.audio_q.put(None)
         else:
             # recorder stopped automatically
             t_stop_press = time.perf_counter()

--- a/webapp/backend/realtime.py
+++ b/webapp/backend/realtime.py
@@ -101,6 +101,9 @@ class RealtimeSession:
         # Allow final chunks to arrive before signaling end-of-stream
         time.sleep(0.5)
         self.audio_q.put(None)
+        extra_sentinels = int(self.phon_thread.realtime) + int(self.asr_thread.realtime) - 1
+        for _ in range(max(extra_sentinels, 0)):
+            self.audio_q.put(None)
 
         # Stop any realtime threads first so they finish consuming the queue
         if self.phon_thread.realtime:


### PR DESCRIPTION
## Summary
- ensure all wav2vec2 threads receive end-of-stream signal
- do so in both RecorderPipeline and RealtimeSession

## Testing
- `python -m py_compile FASE2_recorder_pipeline.py webapp/backend/realtime.py`

------
https://chatgpt.com/codex/tasks/task_e_688a42029460832795aab39e99bab91b