### PR TITLE
Fix audio worklet loading path

### DIFF
--- a/frontend-react/public/pcm-worklet.js
+++ b/frontend-react/public/pcm-worklet.js
@@ -1,0 +1,17 @@
+class PCMProcessor extends AudioWorkletProcessor {
+  process(inputs) {
+    const input = inputs[0];
+    if (input && input[0]) {
+      const samples = input[0];
+      const pcm = new Int16Array(samples.length);
+      for (let i = 0; i < samples.length; i++) {
+        const s = Math.max(-1, Math.min(1, samples[i]));
+        pcm[i] = s * 32767;
+      }
+      this.port.postMessage(pcm);
+    }
+    return true;
+  }
+}
+
+registerProcessor('pcm-processor', PCMProcessor);

--- a/frontend-react/src/hooks/useRecorder.ts
+++ b/frontend-react/src/hooks/useRecorder.ts
@@ -118,7 +118,7 @@ export function useRecorder({ sentence, teacherId, studentId, onFeedback, canvas
     dataArrayRef.current = dataArray;
 
     await audioCtx.audioWorklet.addModule(
-      new URL('../worklets/pcm-processor.ts', import.meta.url),
+      `${import.meta.env.BASE_URL}pcm-worklet.js`,
     );
     const processor = new AudioWorkletNode(audioCtx, 'pcm-processor');
     processorRef.current = processor;


### PR DESCRIPTION
## Summary
- serve the PCM worklet script as a static asset
- load the worklet using `import.meta.env.BASE_URL`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a564479988327a69bdae0a0e57c9a