### PR TITLE
Improve recorder startup robustness

### DIFF
--- a/FASE2_audio.py
+++ b/FASE2_audio.py
@@ -141,6 +141,21 @@ class AudioRecorder:
             console.print(f"[green]▶ Recording started:[/green] [cyan]SR={self.sample_rate} Hz[/cyan], [cyan]block={self.block_duration_ms} ms[/cyan]\n")
         except Exception as e:
             console.print(f"[red]✖ Failed to start audio stream:[/red] {e}")
+            self._running.clear()
+            if self._stream:
+                try:
+                    self._stream.close()
+                except Exception:
+                    pass
+                self._stream = None
+            if self.wavefile:
+                self.wavefile.close()
+                self.wavefile = None
+                # remove partially created file
+                try:
+                    Path(self.filename).unlink(missing_ok=True)
+                except Exception:
+                    pass
             return
 
         if max_duration_s is not None:


### PR DESCRIPTION
## Summary
- better handle audio start failures so any open stream and wave file are closed

## Testing
- `python -m py_compile FASE2_audio.py`
- `python -m unittest discover || true`
- `flake8 || true`


------
https://chatgpt.com/codex/tasks/task_e_688a5ec899d48327a7f8286fdb59d80e