### PR TITLE
Handle zero-length audio inputs

### DIFF
--- a/FASE2_azure_process.py
+++ b/FASE2_azure_process.py
@@ -159,6 +159,10 @@ class AzurePronunciationEvaluator:
 
     def process_file(self, wav_path: str):
         """Run pronunciation assessment on a saved WAV."""
+        if os.path.getsize(wav_path) == 0:
+            if self.results is not None:
+                self.results["azure_pronunciation"]["final_transcript"] = ""
+            return
         audio_config = speechsdk.audio.AudioConfig(filename=wav_path)
         recognizer = speechsdk.SpeechRecognizer(
             speech_config=self.speech_config,
@@ -290,6 +294,10 @@ class AzurePlainTranscriber:
 
     def process_file(self, wav_path: str):
         """Transcribe a saved WAV using Azure."""
+        if os.path.getsize(wav_path) == 0:
+            if self.results is not None:
+                self.results["azure_plain"]["final_transcript"] = ""
+            return
         audio_config = speechsdk.audio.AudioConfig(filename=wav_path)
         recognizer = speechsdk.SpeechRecognizer(
             speech_config=self.speech_config,

--- a/FASE2_wav2vec2_process.py
+++ b/FASE2_wav2vec2_process.py
@@ -186,6 +186,14 @@ class Wav2Vec2PhonemeExtractor(threading.Thread):
         import soundfile as sf
 
         data, sr = sf.read(wav_path)
+        # Skip processing if the file is empty
+        if data.size == 0:
+            if self.results is not None:
+                self.results["wav2vec2_phonemes"].append({
+                    "timestamp": "0",
+                    "phonemes": []
+                })
+            return
         if sr != 16000:
             data = resampy.resample(data, sr, 16000)
         if data.ndim > 1:
@@ -342,6 +350,13 @@ class Wav2Vec2Transcriber(threading.Thread):
         import soundfile as sf
 
         data, sr = sf.read(wav_path)
+        if data.size == 0:
+            if self.results is not None:
+                self.results["wav2vec2_asr"].append({
+                    "timestamp": "0",
+                    "transcript": ""
+                })
+            return
         if sr != 16000:
             data = resampy.resample(data, sr, 16000)
         if data.ndim > 1:


### PR DESCRIPTION
## Summary
- avoid resampling empty recordings in wav2vec2 processing
- skip Azure processing when wav file has no audio

## Testing
- `python -m py_compile FASE2_wav2vec2_process.py FASE2_azure_process.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a639b394083279c9a7ef7eba064d5