### PR TITLE
feat: allow azure to consume shared audio

### DIFF
--- a/FASE2_tutor_loop.py
+++ b/FASE2_tutor_loop.py
@@ -62,6 +62,8 @@ REALTIME_FLAGS = {
 # Run offline engines in parallel?
 PARALLEL_OFFLINE = True
 CHUNK_DURATION = 10
+# Stream audio from the recorder to Azure instead of using a second microphone
+AZURE_PUSH_STREAM = True
 
 def save_json(payload: dict):
     """Serialize results to file for later analysis."""
@@ -74,7 +76,8 @@ def save_json(payload: dict):
 # ────────────────── MAIN LOOP ───────────────
 def main():
     pipeline = RecorderPipeline(rt_flags=REALTIME_FLAGS,
-                                chunk_duration=CHUNK_DURATION)
+                                chunk_duration=CHUNK_DURATION,
+                                use_push_to_azure=AZURE_PUSH_STREAM)
 
     for sentence in SENTENCES:
         need_prompt = True


### PR DESCRIPTION
## Summary
- allow Azure pronunciation and plain transcribers to optionally read audio from the same recorder queue via PushAudioInputStream
- RecorderPipeline can now route microphone audio to Azure engines for a single mic setup
- tutor loop exposes flag to toggle shared Azure audio stream

## Testing
- `python -m py_compile FASE2_azure_process.py FASE2_recorder_pipeline.py FASE2_tutor_loop.py`


------
https://chatgpt.com/codex/tasks/task_e_688f51006e7483278a59b8a4ebd12945