### PR TITLE
Fix wav2vec2 real-time shutdown to capture results

### DIFF
--- a/webapp/backend/realtime.py
+++ b/webapp/backend/realtime.py
@@ -108,13 +108,17 @@ class RealtimeSession:
         self.asr_q.put(None)
         self.wavefile.close()
         if self.phon_thread.realtime:
-            self.phon_thread.stop()
+            # Allow the thread to drain remaining audio from the queue.
+            # A sentinel has already been enqueued, so simply join instead
+            # of calling ``stop()``; forcing ``stop()`` here can interrupt
+            # processing and yield empty results.
             self.phon_thread.join()
         else:
             self.phon_thread.process_file(self.wav_path)
 
         if self.asr_thread.realtime:
-            self.asr_thread.stop()
+            # Same reasoning as above – joining lets the transcriber finish
+            # processing any buffered audio before exiting.
             self.asr_thread.join()
         else:
             self.asr_thread.process_file(self.wav_path)


### PR DESCRIPTION
## Summary
- prevent premature stopping of wav2vec2 threads in `RealtimeSession.stop`
- join wav2vec2 extractor/transcriber threads after enqueueing sentinel so remaining audio is processed

## Testing
- `python -m py_compile webapp/backend/realtime.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688f5e2ed7048327b40ba1c7befc33c7