### PR TITLE
feat(frontend): add interactive direction choices

### DIFF
--- a/frontend-react/src/components/story/InteractiveSentence.tsx
+++ b/frontend-react/src/components/story/InteractiveSentence.tsx
@@ -1,0 +1,36 @@
+interface InteractiveSentenceProps {
+  text: string;
+  audio: string;
+  words?: string[];
+  className?: string;
+}
+
+export function InteractiveSentence({ text, audio, words, className }: InteractiveSentenceProps) {
+  return (
+    <p className={"text-[2rem] " + (className ?? "")}> 
+      {text.split(" ").map((w, i) => (
+        <span
+          key={i}
+          className="word cursor-pointer hover:text-primary transition-colors"
+          onClick={(e) => {
+            e.stopPropagation();
+            if (words && words[i]) new Audio("/api/audio/" + words[i]).play();
+          }}
+        >
+          {w}&nbsp;
+        </span>
+      ))}
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          new Audio("/api/audio/" + audio).play();
+        }}
+        className="inline-flex items-center justify-center ml-2 p-2 rounded-full bg-primary text-white"
+      >
+        <i className="lucide lucide-volume-2" />
+      </button>
+    </p>
+  );
+}
+

--- a/frontend-react/src/components/story/SentenceDisplay.tsx
+++ b/frontend-react/src/components/story/SentenceDisplay.tsx
@@ -1,82 +1,55 @@
+import { InteractiveSentence } from './InteractiveSentence';
+
 interface SentenceItem {
-  type: "sentence";
+  type: 'sentence';
   text: string;
   audio: string;
   words?: string[];
 }
 
 interface DirectionItem {
-  type: "direction";
+  type: 'direction';
   text: string;
   audio: string;
+  words?: string[];
 }
 
 export type StoryItem = SentenceItem | DirectionItem;
 
 interface SentenceDisplayProps {
   item: StoryItem | null;
-  selectedDirection: number | null;
-  setSelectedDirection: (n: number | null) => void;
+  nextItem: StoryItem | null;
+  onDirectionSelect: (n: number) => void;
 }
 
 export function SentenceDisplay({
   item,
-  selectedDirection,
-  setSelectedDirection,
+  nextItem,
+  onDirectionSelect,
 }: SentenceDisplayProps) {
   if (!item) return <div className="card">...</div>;
 
-  if (item.type === "direction") {
+  if (item.type === 'direction' && nextItem && nextItem.type === 'direction') {
+    const options = [item, nextItem];
     return (
-      <div className="space-y-2">
-        {[item].map((opt, i) => (
-          <label
+      <div className="flex flex-col sm:flex-row gap-4">
+        {options.map((opt, i) => (
+          <button
             key={i}
-            className="flex items-center gap-2 bg-white p-4 rounded-xl shadow"
+            onClick={() => onDirectionSelect(i)}
+            className="flex-1 bg-white p-4 rounded-xl shadow hover:bg-slate-50 transition hover:scale-[1.02]"
           >
-            <input
-              type="radio"
-              name="direction"
-              value={i}
-              checked={selectedDirection === i}
-              onChange={() => setSelectedDirection(i)}
-            />
-            <span>{opt.text}</span>
-            <button
-              type="button"
-              onClick={() => new Audio("/api/audio/" + opt.audio).play()}
-              className="ml-auto"
-            >
-              <i className="lucide lucide-volume-2" />
-            </button>
-          </label>
+            <InteractiveSentence text={opt.text} audio={opt.audio} words={opt.words} className="text-[1.5rem]" />
+          </button>
         ))}
       </div>
     );
   }
 
-  return (
-    <p className="text-[2rem]">
-      {item.text.split(" ").map((w, i) => (
-        <span
-          key={i}
-          className="word cursor-pointer hover:text-primary transition-colors"
-          onClick={() =>
-            item.words &&
-            item.words[i] &&
-            new Audio("/api/audio/" + item.words![i]).play()
-          }
-        >
-          {w}&nbsp;
-        </span>
-      ))}
-      <button
-        type="button"
-        onClick={() => new Audio("/api/audio/" + item.audio).play()}
-        className="inline-flex items-center justify-center ml-2 p-2 rounded-full bg-primary text-white"
-      >
-        <i className="lucide lucide-volume-2" />
-      </button>
-    </p>
-  );
+  if (item.type === 'sentence') {
+    return <InteractiveSentence text={item.text} audio={item.audio} words={item.words} />;
+  }
+
+  return null;
 }
+


### PR DESCRIPTION
## Summary
- show direction choices side-by-side as tappable cards with TTS and word highlighting
- hide recording controls during direction choices and continue story on selection

## Testing
- `cd frontend-react && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68920676e9508327a1b94b6a1923ed4c