### PR TITLE
feat: show loading page during story direction fetch

### DIFF
--- a/frontend-react/src/main.tsx
+++ b/frontend-react/src/main.tsx
@@ -10,6 +10,7 @@ import PlayPage from './pages/PlayPage';
 import ProgressPage from './pages/ProgressPage';
 import RequireAuth from './components/RequireAuth';
 import StoryPage from './pages/StoryPage';
+import ContinuePage from './pages/ContinuePage';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
@@ -22,6 +23,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
             <Route path="/dashboard/level/:levelId" element={<LevelPage />} />
             <Route path="/play/:levelId/:themeId" element={<PlayPage />} />
             <Route path="/story" element={<StoryPage />} />
+            <Route path="/continue" element={<ContinuePage />} />
             <Route path="/progress" element={<ProgressPage />} />
           </Route>
           <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend-react/src/pages/ContinuePage.tsx
+++ b/frontend-react/src/pages/ContinuePage.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react';
+import AppShell from '@/components/layout/AppShell';
+import { Progress } from '@/components/ui/progress';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import { BookOpen } from 'lucide-react';
+import type { StoryItem } from '@/components/story/SentenceDisplay';
+
+export default function ContinuePage() {
+  const [progress, setProgress] = useState(0);
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    const theme = localStorage.getItem('theme');
+    const level = localStorage.getItem('level');
+    const direction = localStorage.getItem('direction_choice');
+    const idx = Number(localStorage.getItem('direction_index'));
+
+    if (!theme || !level || !direction || Number.isNaN(idx)) {
+      navigate('/');
+      return;
+    }
+
+    const ev = new EventSource(`/api/continue_story?theme=${theme}&level=${level}&direction=${encodeURIComponent(direction)}`);
+    const data: StoryItem[] = [];
+
+    ev.addEventListener('progress', (e) => {
+      setProgress(parseFloat((e as MessageEvent).data) * 100);
+    });
+    ev.addEventListener('sentence', (e) => {
+      data.push({ type: 'sentence', ...(JSON.parse((e as MessageEvent).data)) });
+    });
+    ev.addEventListener('direction', (e) => {
+      data.push({ type: 'direction', ...(JSON.parse((e as MessageEvent).data)) });
+    });
+    ev.addEventListener('complete', () => {
+      ev.close();
+      const story = JSON.parse(localStorage.getItem('story_data') ?? '[]');
+      story.splice(idx, 2, ...data);
+      localStorage.setItem('story_data', JSON.stringify(story));
+      localStorage.setItem('story_index', String(idx));
+      localStorage.removeItem('direction_choice');
+      localStorage.removeItem('direction_index');
+      navigate(`/story${location.search}`);
+    });
+    return () => {
+      ev.close();
+    };
+  }, [navigate, location.search]);
+
+  return (
+    <AppShell>
+      <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="space-y-6 w-full max-w-md text-center">
+        <h2 className="font-title text-xl">Voorbereiden…</h2>
+        <div className="flex justify-center">
+          <motion.div animate={{ rotate: 360 }} transition={{ repeat: Infinity, duration: 2, ease: 'linear' }}>
+            <BookOpen className="h-12 w-12 text-primary" />
+          </motion.div>
+        </div>
+        <Progress value={progress} />
+        <p className="text-sm text-slate-600">{Math.round(progress)}%</p>
+      </motion.div>
+    </AppShell>
+  );
+}


### PR DESCRIPTION
## Summary
- redirect direction choices through a dedicated loading page
- create ContinuePage to fetch next story segment and update stored data
- wire ContinuePage into router and restore story position after loading

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68920c9288d48327befb6ec350b1bdd8