### PR TITLE
Remove unused TTS language setting

### DIFF
--- a/webapp/backend/config.py
+++ b/webapp/backend/config.py
@@ -41,8 +41,8 @@ VOICE_INSTRUCTIONS = (
 )
 
 # Separate model for word-level TTS generation
-WORD_VOICE_MODEL = "tts-1"
-WORD_VOICE_LANGUAGE = "nl"
+WORD_VOICE_MODEL = "gpt-4o-mini-tts"
+WORD_VOICE_INSTRUCTIONS = "Spreek in Nederlands"
 
 # Delay before playing filler sentence after stop (seconds)
 DELAY_SECONDS = 0.5

--- a/webapp/backend/tts.py
+++ b/webapp/backend/tts.py
@@ -55,7 +55,7 @@ def word_tts_to_file(text: str) -> str:
         voice=config.VOICE_NAME,
         input=text,
         response_format="wav",
-        language=config.WORD_VOICE_LANGUAGE,
+        instructions=config.WORD_VOICE_INSTRUCTIONS,
     )
     with open(path, "wb") as f:
         f.write(resp.content)


### PR DESCRIPTION
## Summary
- drop unused language field from word-level TTS
- supply Dutch instructions and update word-level model to gpt-4o-mini-tts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68922417482083278948ebf8a8c75a00