### PR TITLE
Revert commit investigating recording delay

### DIFF
--- a/frontend-react/src/hooks/useRecorder.ts
+++ b/frontend-react/src/hooks/useRecorder.ts
@@ -4,7 +4,6 @@ const SEND_INTERVAL_MS = 100; // how often to upload audio (in ms)
 const DEBUG = false; // set true to enable chunk logs
 const PCM_QUEUE: Int16Array[] = [];
 let lastSend = 0;
-let chunkPromise: Promise<void> = Promise.resolve();
 
 const FILLER_AUDIO = "de_zin_was.wav";
 
@@ -60,20 +59,13 @@ export function useRecorder({
   }, []);
 
   function sendChunk(blob: Blob) {
-    if (!realtimeRef.current || !sessionIdRef.current) return chunkPromise;
+    if (!realtimeRef.current || !sessionIdRef.current) return;
     const form = new FormData();
     form.append("file", blob, "chunk.pcm");
-    chunkPromise = chunkPromise
-      .catch(() => {})
-      .then(() =>
-        fetch(`/api/realtime/chunk/${sessionIdRef.current}`, {
-          method: "POST",
-          body: form,
-        }).then(() => {
-          /* no-op */
-        }),
-      );
-    return chunkPromise;
+    fetch(`/api/realtime/chunk/${sessionIdRef.current}`, {
+      method: "POST",
+      body: form,
+    });
   }
 
   function drawWave(level: number) {
@@ -220,7 +212,6 @@ export function useRecorder({
     processorRef.current?.disconnect();
     streamRef.current?.getTracks().forEach((t) => t.stop());
     const sampleRate = sampleRateRef.current || 48000;
-    const recChunks = recordedChunksRef.current;
     await audioCtxRef.current?.close();
     audioCtxRef.current = null;
     setStatus("Analyseren");
@@ -234,11 +225,8 @@ export function useRecorder({
           pos += c.length;
         }
         PCM_QUEUE.length = 0;
-        await sendChunk(
-          new Blob([flat], { type: "application/octet-stream" }),
-        );
+        sendChunk(new Blob([flat], { type: "application/octet-stream" }));
       }
-      await chunkPromise;
       const stopPromise = fetch(`/api/realtime/stop/${sessionIdRef.current}`, {
         method: "POST",
       }).then(async (r) => {
@@ -267,10 +255,13 @@ export function useRecorder({
           setStatus("Fout: " + (err as Error).message);
           return;
         }
-        const total = recChunks.reduce((n, c) => n + c.length, 0);
+        const total = recordedChunksRef.current.reduce(
+          (n, c) => n + c.length,
+          0,
+        );
         const flat = new Int16Array(total);
         let pos = 0;
-        for (const c of recChunks) {
+        for (const c of recordedChunksRef.current) {
           flat.set(c, pos);
           pos += c.length;
         }
@@ -287,10 +278,10 @@ export function useRecorder({
     }
 
     // Offline mode: process the full recording in one request
-    const total = recChunks.reduce((n, c) => n + c.length, 0);
+    const total = recordedChunksRef.current.reduce((n, c) => n + c.length, 0);
     const flat = new Int16Array(total);
     let pos = 0;
-    for (const c of recChunks) {
+    for (const c of recordedChunksRef.current) {
       flat.set(c, pos);
       pos += c.length;
     }


### PR DESCRIPTION
## Summary
- Revert merge commit ad6d2dd that introduced recording-delay investigation.
- Restore direct chunk sending and recorded chunk aggregation in `useRecorder`.

## Testing
- `pytest`
- `npm test` in `frontend-react`


------
https://chatgpt.com/codex/tasks/task_e_68932d90fd6c83278e7c216319b4959e