### PR TITLE
Refresh audio streams each session

### DIFF
--- a/FASE2_wav2vec2_process.py
+++ b/FASE2_wav2vec2_process.py
@@ -89,9 +89,52 @@ class Wav2Vec2PhonemeExtractor(threading.Thread):
         while self.running:
             try:
                 pcm_frames = self.audio_q.get(timeout=1.0)
-                # Sentinel value None means end-of-stream
                 if pcm_frames is None:
-                    break
+                    if not self.running:
+                        break
+                    if len(self.buffer) > 0:
+                        if self.sample_rate != 16000:
+                            float32_audio = self.buffer.astype(np.float32) / 32768.0
+                            resampled = resampy.resample(float32_audio, self.sample_rate, 16000)
+                            model_input = resampled
+                        else:
+                            model_input = self.buffer.astype(np.float32) / 32768.0
+                        with torch.inference_mode():
+                            inputs = self.processor(
+                                model_input, sampling_rate=16000, return_tensors="pt", padding=True
+                            )
+                            iv = inputs.input_values.to(self.device)
+                            logits = self.model(iv).logits
+                            pred_ids = torch.argmax(logits, dim=-1)
+                            transcription = self.processor.batch_decode(pred_ids)[0]
+                            phonemes = transcription.split()
+                        if not phonemes:
+                            rms = float(np.sqrt(np.mean(model_input ** 2)))
+                            console.log(
+                                f"[yellow][W2V2 phonemes] empty decode; samples={len(model_input)}, rms={rms:.6f}[/yellow]"
+                            )
+                            if self.results is not None:
+                                self.results.setdefault("wav2vec2_phonemes_debug", []).append({
+                                    "stage": "final_chunk",
+                                    "samples": int(len(model_input)),
+                                    "rms": rms,
+                                })
+                        readable_ts = datetime.now().strftime("%H:%M:%S")
+                        if self.results is not None:
+                            self.results["wav2vec2_phonemes"].append({
+                                "timestamp": readable_ts,
+                                "phonemes": phonemes,
+                            })
+                        console.print(
+                            Panel.fit(
+                                Text(f"[{readable_ts}]  {' '.join(phonemes)}", style="white"),
+                                title="[bold magenta]Phonemes (Wav2Vec2)[/bold magenta]  (final short chunk)",
+                                border_style="magenta",
+                                width=80,
+                            )
+                        )
+                        self.buffer = np.zeros((0,), dtype=np.int16)
+                    continue
             except queue.Empty:
                 continue
             self.buffer = np.concatenate((self.buffer, pcm_frames), axis=0)
@@ -191,6 +234,14 @@ class Wav2Vec2PhonemeExtractor(threading.Thread):
 
     def stop(self):
         self.running = False
+        try:
+            self.audio_q.put_nowait(None)
+        except Exception:
+            pass
+        try:
+            self.audio_q.put_nowait(None)
+        except Exception:
+            pass
 
     # ------------------------------------------------------------------ offline
     def process_file(self, wav_path: str):
@@ -289,9 +340,49 @@ class Wav2Vec2Transcriber(threading.Thread):
         while self.running:
             try:
                 pcm_frames = self.audio_q.get(timeout=1.0)
-                # Sentinel value None means end-of-stream
                 if pcm_frames is None:
-                    break
+                    if not self.running:
+                        break
+                    if len(self.buffer) > 0:
+                        if self.sample_rate != 16000:
+                            float_chunk = self.buffer.astype(np.float32) / 32768.0
+                            float_chunk = resampy.resample(float_chunk, self.sample_rate, 16000)
+                        else:
+                            float_chunk = self.buffer.astype(np.float32) / 32768.0
+                        input_values = self.processor(
+                            float_chunk, sampling_rate=16000, return_tensors="pt", padding=True
+                        ).input_values.to(self.device)
+                        with torch.inference_mode():
+                            logits = self.model(input_values).logits
+                            pred_ids = torch.argmax(logits, dim=-1)
+                            transcript = self.processor.batch_decode(pred_ids)[0]
+                        ts = datetime.now().strftime("%H:%M:%S")
+                        if not transcript.strip():
+                            rms = float(np.sqrt(np.mean(float_chunk ** 2)))
+                            console.log(
+                                f"[yellow][W2V2 ASR] empty decode; samples={len(float_chunk)}, rms={rms:.6f}[/yellow]"
+                            )
+                            if self.results is not None:
+                                self.results.setdefault("wav2vec2_asr_debug", []).append({
+                                    "stage": "final_chunk",
+                                    "samples": int(len(float_chunk)),
+                                    "rms": rms,
+                                })
+                        if self.results is not None:
+                            self.results["wav2vec2_asr"].append({
+                                "timestamp": ts,
+                                "transcript": transcript,
+                            })
+                        console.print(
+                            Panel.fit(
+                                Text(f"[{ts}]  {transcript}", style="white"),
+                                title="[bold cyan]ASR Text (Wav2Vec2)[/bold cyan]  (final short chunk)",
+                                border_style="cyan",
+                                width=80,
+                            )
+                        )
+                        self.buffer = np.zeros((0,), dtype=np.int16)
+                    continue
             except queue.Empty:
                 continue
 

--- a/webapp/backend/session_manager.py
+++ b/webapp/backend/session_manager.py
@@ -53,7 +53,6 @@ class EnginePool:
                 teacher_id=teacher_id,
                 student_id=student_id,
             )
-            sess._init_engines()
         return sess, old_id
 
     def cleanup(self, max_idle: float = 600.0) -> None:


### PR DESCRIPTION
## Summary
- Rebuild Azure push streams and audio queues for every recording without recreating recognizers
- Keep wav2vec2 phoneme/ASR threads alive by draining queues on sentinel frames
- Reuse realtime sessions in EnginePool by resetting state only

## Testing
- `python -m py_compile FASE2_azure_process.py FASE2_wav2vec2_process.py webapp/backend/realtime.py webapp/backend/session_manager.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689337c5d6dc83278fda3b10da6b2a1b