### PR TITLE
Restart audio feed threads between recordings

### DIFF
--- a/FASE2_azure_process.py
+++ b/FASE2_azure_process.py
@@ -23,6 +23,24 @@ from rich.panel import Panel
 console = Console()
 
 
+def _feed_worker(audio_queue: queue.Queue | None, push_stream) -> None:
+    """Forward PCM frames from a queue into an Azure push stream."""
+    if push_stream is None or audio_queue is None:
+        return
+    while True:
+        pcm = audio_queue.get()
+        if pcm is None:
+            break
+        try:
+            push_stream.write(pcm.tobytes())
+        except Exception:
+            break
+    try:
+        push_stream.close()
+    except Exception:
+        pass
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Pronunciation Evaluator
 # ─────────────────────────────────────────────────────────────────────────────
@@ -228,6 +246,13 @@ class AzurePronunciationEvaluator:
         self._done_event.wait(timeout=timeout)
         console.print("[red]■ Azure Pron stopped.[/red]\n")
 
+    def start_continuous_recognition_async(self):
+        if not self.realtime or self._running:
+            return
+        self._running = True
+        self._done_event.clear()
+        self.recognizer.start_continuous_recognition_async()
+
     def update_reference_text(self, text: str):
         """Replace the reference sentence used for pronunciation scoring."""
         self.reference_text = text
@@ -268,7 +293,12 @@ class AzurePronunciationEvaluator:
         except Exception:
             # Fallback in case the private API changes
             self.recognizer.audio_config = audio_config  # type: ignore[attr-defined]
-        self._feed_thread = None
+        if self._feed_thread and self._feed_thread.is_alive():
+            self._feed_thread.join()
+        self._feed_thread = threading.Thread(
+            target=_feed_worker, args=(self.audio_queue, self._push_stream), daemon=True
+        )
+        self._feed_thread.start()
 
     def process_file(self, wav_path: str):
         """Run pronunciation assessment on a saved WAV."""
@@ -450,6 +480,13 @@ class AzurePlainTranscriber:
         self._done_event.wait(timeout=timeout)
         console.print("[red]■ Azure Plain stopped.[/red]\n")
 
+    def start_continuous_recognition_async(self):
+        if not self.realtime or self._running:
+            return
+        self._running = True
+        self._done_event.clear()
+        self.recognizer.start_continuous_recognition_async()
+
     def process_file(self, wav_path: str):
         """Transcribe a saved WAV using Azure."""
         if os.path.getsize(wav_path) == 0:
@@ -487,4 +524,9 @@ class AzurePlainTranscriber:
             self.recognizer._impl.set_audio_config(audio_config._impl)
         except Exception:
             self.recognizer.audio_config = audio_config  # type: ignore[attr-defined]
-        self._feed_thread = None
+        if self._feed_thread and self._feed_thread.is_alive():
+            self._feed_thread.join()
+        self._feed_thread = threading.Thread(
+            target=_feed_worker, args=(self.audio_queue, self._push_stream), daemon=True
+        )
+        self._feed_thread.start()

--- a/FASE2_wav2vec2_process.py
+++ b/FASE2_wav2vec2_process.py
@@ -283,6 +283,11 @@ class Wav2Vec2Transcriber(threading.Thread):
         self.model.eval()
         console.print("[cyan]✅  Model loaded and ready.[/cyan]\n")
 
+    def reset_queue(self, new_queue: queue.Queue) -> None:
+        """Install a fresh audio queue and clear the internal buffer."""
+        self.audio_q = new_queue
+        self.buffer = np.zeros((0,), dtype=np.int16)
+
     def run(self):
         if not self.realtime:
             return


### PR DESCRIPTION
## Summary
- restart Azure feed threads when swapping audio queues
- allow Wav2Vec2 ASR thread to accept fresh queues
- restart Azure recognizers asynchronously on session reset and join feed threads on stop

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894ed6867a083279e8d39266a49012a