### PR TITLE
Revert audio feed thread management changes

### DIFF
--- a/FASE2_wav2vec2_process.py
+++ b/FASE2_wav2vec2_process.py
@@ -283,11 +283,6 @@ class Wav2Vec2Transcriber(threading.Thread):
         self.model.eval()
         console.print("[cyan]✅  Model loaded and ready.[/cyan]\n")
 
-    def reset_queue(self, new_queue: queue.Queue) -> None:
-        """Install a fresh audio queue and clear the internal buffer."""
-        self.audio_q = new_queue
-        self.buffer = np.zeros((0,), dtype=np.int16)
-
     def run(self):
         if not self.realtime:
             return

--- a/webapp/backend/realtime.py
+++ b/webapp/backend/realtime.py
@@ -86,15 +86,16 @@ class RealtimeSession:
             self.phon_thread.audio_q = self.phon_q
             self.phon_thread.buffer = np.zeros((0,), dtype=np.int16)
         if getattr(self, "asr_thread", None) is not None:
-            self.asr_thread.reset_queue(self.asr_q)
+            self.asr_thread.audio_q = self.asr_q
+            self.asr_thread.buffer = np.zeros((0,), dtype=np.int16)
         if getattr(self, "azure_pron", None) is not None and self.azure_pron_q is not None:
             self.azure_pron.reset_stream(self.azure_pron_q, self.sample_rate)
             if self.azure_pron.realtime:
-                self.azure_pron.start_continuous_recognition_async()
+                self.azure_pron.start()
         if getattr(self, "azure_plain", None) is not None and self.azure_plain_q is not None:
             self.azure_plain.reset_stream(self.azure_plain_q, self.sample_rate)
             if self.azure_plain.realtime:
-                self.azure_plain.start_continuous_recognition_async()
+                self.azure_plain.start()
 
         self.results.clear()
         self.results.update(
@@ -248,11 +249,6 @@ class RealtimeSession:
             self.azure_plain.stop()
         else:
             self.azure_plain.process_file(self.wav_path)
-
-        if getattr(self.azure_pron, "_feed_thread", None) is not None:
-            self.azure_pron._feed_thread.join()
-        if getattr(self.azure_plain, "_feed_thread", None) is not None:
-            self.azure_plain._feed_thread.join()
 
         console.log(f"wrote {self.chunk_count} chunks totalling {os.path.getsize(self.wav_path)} bytes")
         self.results["end_time"] = time.time()


### PR DESCRIPTION
## Summary
- Revert merge commit that modified audio feed thread management
- Restore prior Azure pronunciation/transcription stream handling
- Reinstate previous Wav2Vec2 processing and realtime session logic

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68957fb5444c8327ae813268d52bd8d9