### PR TITLE
Keep Azure recognizers hot across recordings

### DIFF
--- a/scripts/print_timeline.py
+++ b/scripts/print_timeline.py
@@ -21,7 +21,8 @@ def main(path: str) -> None:
     print("Backend timings (ms):")
     for a, b, label in [
         ("/start_in", "engine_reset_done", "engine reset"),
-        ("azure_start_called", "azure_session_started", "azure handshake"),
+        ("azure_start_called", "azure_start_returned", "azure start call"),
+        ("azure_start_called", "azure_handshake_first_event", "azure handshake"),
         ("first_chunk_received", "azure_first_write", "azure first write"),
         ("w2v2_ready_ph", "w2v2_first_decode", "w2v2 first decode"),
         ("/stop_in", "json_ready", "/stop roundtrip"),

--- a/webapp/backend/config.py
+++ b/webapp/backend/config.py
@@ -67,6 +67,9 @@ CHUNK_DURATION = 10
 # RecorderPipeline and RealtimeSession.
 AZURE_PUSH_STREAM = True
 
+# Keep Azure recognisers alive between recordings and start them asynchronously
+KEEP_AZURE_RUNNING = True
+
 # GPT model settings
 GPT_PROVIDER = os.getenv("GPT_TUTOR_PROVIDER", "openai")
 GPT_MODEL = os.getenv("GPT_TUTOR_MODEL", "gpt-4o-mini")

--- a/webapp/backend/main.py
+++ b/webapp/backend/main.py
@@ -81,7 +81,8 @@ def _print_timeline(results: dict) -> None:
     print("Backend timings (ms):")
     for a, b, label in [
         ("/start_in", "engine_reset_done", "engine reset"),
-        ("azure_start_called", "azure_session_started", "azure handshake"),
+        ("azure_start_called", "azure_start_returned", "azure start call"),
+        ("azure_start_called", "azure_handshake_first_event", "azure handshake"),
         ("first_chunk_received", "azure_first_write", "azure first write"),
         ("w2v2_ready_ph", "w2v2_first_decode", "w2v2 first decode"),
         ("/stop_in", "json_ready", "/stop roundtrip"),


### PR DESCRIPTION
## Summary
- add `KEEP_AZURE_RUNNING` flag to keep Azure recognisers alive
- make Azure pronunciation/transcription engines long-lived with idempotent start/stop helpers
- start Azure asynchronously and avoid shutdown between recordings; update timeline tooling

## Testing
- `python -m py_compile webapp/backend/config.py FASE2_azure_process.py webapp/backend/realtime.py scripts/print_timeline.py webapp/backend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68961feb800c83278cbd56ba75081832