### PR TITLE
feat: add pre-roll ring buffer for recordings

### DIFF
--- a/frontend-react/src/hooks/useRecorder.ts
+++ b/frontend-react/src/hooks/useRecorder.ts
@@ -1,9 +1,11 @@
 import { useEffect, useRef, useState } from "react";
+import { RingBufferInt16 } from "../utils/ringBuffer";
 
 const SEND_INTERVAL_MS = 100; // how often to upload audio (in ms)
 const DEBUG = false; // set true to enable chunk logs
 const PCM_QUEUE: Int16Array[] = [];
 let lastSend = 0;
+const PRELOAD_MS = Number(import.meta.env.VITE_RECORDING_PRELOAD_MS) || 2000;
 
 const FILLER_AUDIO = "de_zin_was.wav";
 
@@ -48,6 +50,8 @@ export function useRecorder({
   const rafRef = useRef<number | null>(null);
   const realtimeRef = useRef(true);
   const timelineRef = useRef<Record<string, number>>({});
+  const ringRef = useRef<RingBufferInt16 | null>(null);
+  const backendReadyRef = useRef(false);
 
   // Fetch runtime config (realtime flag) once
   useEffect(() => {
@@ -114,33 +118,55 @@ export function useRecorder({
     lastSend = 0;
 
     if (realtimeRef.current) {
+      const cap = Math.floor((audioCtx.sampleRate * PRELOAD_MS) / 1000);
+      ringRef.current = new RingBufferInt16(cap);
+      backendReadyRef.current = false;
       const fd = new FormData();
       fd.append("sentence", sentence);
       fd.append("sample_rate", String(audioCtx.sampleRate));
       fd.append("teacher_id", String(teacherId));
       fd.append("student_id", studentId);
-      try {
-        timelineRef.current.start_req_sent = performance.now();
-        const r = await fetch("/api/realtime/start", {
-          method: "POST",
-          body: fd,
-        });
-        const j = await r.json();
-        if (!r.ok) throw new Error(j.detail);
-        sessionIdRef.current = j.session_id;
-        delayRef.current = j.delay_seconds;
-        timelineRef.current.start_resp_ok = performance.now();
-      } catch (err) {
-        setStatus(
-          "Fout: " + (err instanceof Error ? err.message : String(err)),
-        );
-        await audioCtx.close();
-        audioCtxRef.current = null;
-        return;
-      }
+      (async () => {
+        try {
+          timelineRef.current.start_req_sent = performance.now();
+          const r = await fetch("/api/realtime/start", {
+            method: "POST",
+            body: fd,
+          });
+          const j = await r.json();
+          if (!r.ok) throw new Error(j.detail);
+          sessionIdRef.current = j.session_id;
+          delayRef.current = j.delay_seconds;
+          timelineRef.current.start_resp_ok = performance.now();
+          backendReadyRef.current = true;
+          const preload = ringRef.current.drainAll();
+          const ms = (preload.length / audioCtx.sampleRate) * 1000;
+          timelineRef.current.ring_capacity_samples = ringRef.current.capacity;
+          timelineRef.current.ring_preload_samples_sent = preload.length;
+          timelineRef.current.ring_preload_ms = ms;
+          if (preload.length)
+            sendChunk(new Blob([preload], { type: "application/octet-stream" }));
+          console.log(
+            `Frontend: preload_sent_ms=${ms.toFixed(1)}, samples=${preload.length}`,
+          );
+        } catch (err) {
+          console.error("start failed", err);
+          setStatus(
+            "Fout: " + (err instanceof Error ? err.message : String(err)),
+          );
+          recordingRef.current = false;
+          setRecording(false);
+          processorRef.current?.disconnect();
+          streamRef.current?.getTracks().forEach((t) => t.stop());
+          await audioCtxRef.current?.close();
+          audioCtxRef.current = null;
+          ringRef.current?.clear();
+        }
+      })();
     } else {
       sessionIdRef.current = null;
       delayRef.current = 0;
+      backendReadyRef.current = true;
     }
 
     let stream: MediaStream;
@@ -186,6 +212,10 @@ export function useRecorder({
         timelineRef.current.first_chunk_captured = performance.now();
       recordedChunksRef.current.push(pcm);
       if (!realtimeRef.current) return;
+      if (!backendReadyRef.current) {
+        ringRef.current?.push(pcm);
+        return;
+      }
       PCM_QUEUE.push(pcm);
       const now = performance.now();
       if (now - lastSend < SEND_INTERVAL_MS) return;
@@ -219,6 +249,9 @@ export function useRecorder({
     console.log("stopRecording");
     recordingRef.current = false;
     setRecording(false);
+    backendReadyRef.current = false;
+    ringRef.current?.clear();
+    ringRef.current = null;
     if (rafRef.current) cancelAnimationFrame(rafRef.current);
     drawWave(0);
     processorRef.current?.disconnect();

--- a/frontend-react/src/utils/ringBuffer.test.ts
+++ b/frontend-react/src/utils/ringBuffer.test.ts
@@ -1,0 +1,10 @@
+import { RingBufferInt16 } from './ringBuffer';
+
+test('RingBufferInt16 overwrites old data', () => {
+  const rb = new RingBufferInt16(5);
+  rb.push(new Int16Array([1, 2, 3, 4]));
+  rb.push(new Int16Array([5, 6, 7]));
+  expect(rb.lengthSamples).toBe(5);
+  expect(Array.from(rb.drainAll())).toEqual([3, 4, 5, 6, 7]);
+  expect(rb.lengthSamples).toBe(0);
+});

--- a/frontend-react/src/utils/ringBuffer.ts
+++ b/frontend-react/src/utils/ringBuffer.ts
@@ -1,0 +1,40 @@
+export class RingBufferInt16 {
+  private buf: Int16Array;
+  private write = 0;
+  private size = 0;
+
+  constructor(capacitySamples: number) {
+    this.buf = new Int16Array(capacitySamples);
+  }
+
+  clear() {
+    this.write = 0;
+    this.size = 0;
+  }
+
+  push(chunk: Int16Array) {
+    let start = 0;
+    if (chunk.length > this.buf.length) start = chunk.length - this.buf.length;
+    for (let i = start; i < chunk.length; i++) {
+      this.buf[this.write] = chunk[i];
+      this.write = (this.write + 1) % this.buf.length;
+      if (this.size < this.buf.length) this.size++;
+    }
+  }
+
+  drainAll(): Int16Array {
+    const out = new Int16Array(this.size);
+    const start = (this.write - this.size + this.buf.length) % this.buf.length;
+    for (let i = 0; i < this.size; i++)
+      out[i] = this.buf[(start + i) % this.buf.length];
+    this.size = 0;
+    return out;
+  }
+
+  get lengthSamples() {
+    return this.size;
+  }
+  get capacity() {
+    return this.buf.length;
+  }
+}


### PR DESCRIPTION
## Summary
- add an Int16 ring buffer to capture audio before the backend session is ready
- flush buffered audio once realtime session starts and log preload metrics
- unit test the ring buffer implementation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68965190eca08327bef746f55bd14b08