### PR TITLE
Highlight incorrect words in sentences

### DIFF
--- a/frontend-react/src/pages/StoryPage.tsx
+++ b/frontend-react/src/pages/StoryPage.tsx
@@ -85,16 +85,24 @@ export default function StoryPage() {
   }, [feedback]);
 
   const highlights: Highlights = useMemo(() => {
-    if (!feedback?.errors || !currentItem || currentItem.type !== 'sentence')
-      return {};
-    const ref = currentItem.text.replace(/[.!?;:]/g, '').toLowerCase();
-    const tokens = ref.split(/\s+/);
+    if (!feedback?.errors || !currentItem || currentItem.type !== 'sentence') return {};
+
+    // Split the *displayed* text the same way SentenceDisplay does
+    const words = currentItem.text.split(/\s+/);
+
+    // Normalize words for matching (strip punctuation, lowercase)
+    const norm = (s: string) => s.replace(/[^\p{L}\p{N}']/gu, '').toLowerCase();
+
     const bad = new Set(
-      feedback.errors.map((e) => e.expected_word?.toLowerCase?.() || ''),
+      feedback.errors
+        .map((e) => (e.expected_word ?? '').toString())
+        .map(norm)
+        .filter(Boolean),
     );
+
     const map: Highlights = {};
-    tokens.forEach((w, i) => {
-      if (bad.has(w)) map[i] = 'error';
+    words.forEach((w, i) => {
+      if (bad.has(norm(w))) map[i] = 'error';
     });
     return map;
   }, [feedback, currentItem]);


### PR DESCRIPTION
## Summary
- refine sentence error highlighting by matching normalized words against feedback errors

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68971850870c83279b168be22e6f5342