### PR TITLE
feat: add word-level feedback highlighting

### DIFF
--- a/frontend-react/src/__tests__/highlight.test.ts
+++ b/frontend-react/src/__tests__/highlight.test.ts
@@ -1,0 +1,45 @@
+import { buildHighlightMap, normalize, WordError } from '../utils/highlight';
+
+test('perfect read marks all words correct', () => {
+  const ref = 'De kat zit';
+  const res = buildHighlightMap(ref, [], true);
+  expect(res.map).toEqual({0:'correct',1:'correct',2:'correct'});
+});
+
+test('mispronounced word highlights only that word', () => {
+  const ref = 'De kat zit';
+  const errors: WordError[] = [{expected_word:'kat', issue:'mispronunciation'}];
+  const res = buildHighlightMap(ref, errors, false);
+  expect(res.map[1]).toBe('error');
+  expect(res.map[0]).toBeUndefined();
+  expect(res.map[2]).toBeUndefined();
+});
+
+test('omitted word highlights missing token', () => {
+  const ref = 'De kat zit';
+  const errors: WordError[] = [{expected_word:'zit', issue:'omission'}];
+  const res = buildHighlightMap(ref, errors, false);
+  expect(res.map[2]).toBe('error');
+});
+
+test('insertion marks previous token with dotted underline', () => {
+  const ref = 'Ik zie een kat';
+  const errors: WordError[] = [{expected_word:'', heard_word:'de', issue:'insertion'}];
+  const res = buildHighlightMap(ref, errors, false);
+  expect(res.insertions).toEqual([0]);
+});
+
+test('duplicate words consume left to right', () => {
+  const ref = 'de de kat';
+  const errors: WordError[] = [
+    {expected_word:'de', issue:'mispronunciation'},
+    {expected_word:'de', issue:'omission'},
+  ];
+  const res = buildHighlightMap(ref, errors, false);
+  expect(res.map).toEqual({0:'error',1:'error'});
+});
+
+test('normalize strips punctuation and case', () => {
+  expect(normalize('Kat.')).toBe('kat');
+  expect(normalize('"Hond"')).toBe('hond');
+});

--- a/frontend-react/src/components/story/InteractiveSentence.tsx
+++ b/frontend-react/src/components/story/InteractiveSentence.tsx
@@ -3,28 +3,53 @@ interface InteractiveSentenceProps {
   audio: string;
   words?: string[];
   className?: string;
+  highlights?: Record<number, 'error' | 'correct'>;
+  insertions?: number[];
 }
 
-export function InteractiveSentence({ text, audio, words, className }: InteractiveSentenceProps) {
+export function InteractiveSentence({
+  text,
+  audio,
+  words,
+  className,
+  highlights,
+  insertions,
+}: InteractiveSentenceProps) {
+  const tokens = text.split(/\s+/);
+  const insSet = new Set(insertions ?? []);
   return (
-    <p className={"text-[2rem] " + (className ?? "")}> 
-      {text.split(" ").map((w, i) => (
-        <span
-          key={i}
-          className="word cursor-pointer hover:text-primary transition-colors"
-          onClick={(e) => {
-            e.stopPropagation();
-            if (words && words[i]) new Audio("/api/audio/" + words[i]).play();
-          }}
-        >
-          {w}&nbsp;
-        </span>
-      ))}
+    <p className={"text-[2rem] " + (className ?? "")}>
+      {tokens.map((w, i) => {
+        const mark = highlights?.[i];
+        const cls = [
+          'word cursor-pointer transition-colors hover:text-primary',
+          mark === 'error' && 'token-error',
+          mark === 'correct' && 'token-correct',
+          insSet.has(i) && 'token-insert-near',
+        ]
+          .filter(Boolean)
+          .join(' ');
+        return (
+          <span
+            key={i}
+            className={cls}
+            aria-label={mark === 'error' ? `Fout in woord ‘${w}’` : undefined}
+            onClick={(e) => {
+              e.stopPropagation();
+              if (words && words[i]) new Audio('/api/audio/' + words[i]).play();
+            }}
+          >
+            {w}
+            {mark === 'error' && <sup className="text-red-600 ml-0.5">!</sup>}
+            {' '}
+          </span>
+        );
+      })}
       <button
         type="button"
         onClick={(e) => {
           e.stopPropagation();
-          new Audio("/api/audio/" + audio).play();
+          new Audio('/api/audio/' + audio).play();
         }}
         className="inline-flex items-center justify-center ml-2 p-2 rounded-full bg-primary text-white"
       >
@@ -33,4 +58,3 @@ export function InteractiveSentence({ text, audio, words, className }: Interacti
     </p>
   );
 }
-

--- a/frontend-react/src/components/story/SentenceDisplay.tsx
+++ b/frontend-react/src/components/story/SentenceDisplay.tsx
@@ -20,12 +20,16 @@ interface SentenceDisplayProps {
   item: StoryItem | null;
   nextItem: StoryItem | null;
   onDirectionSelect: (n: number) => void;
+  highlights?: Record<number, 'error' | 'correct'>;
+  insertions?: number[];
 }
 
 export function SentenceDisplay({
   item,
   nextItem,
   onDirectionSelect,
+  highlights,
+  insertions,
 }: SentenceDisplayProps) {
   if (!item) return <div className="card">...</div>;
 
@@ -47,7 +51,15 @@ export function SentenceDisplay({
   }
 
   if (item.type === 'sentence') {
-    return <InteractiveSentence text={item.text} audio={item.audio} words={item.words} />;
+    return (
+      <InteractiveSentence
+        text={item.text}
+        audio={item.audio}
+        words={item.words}
+        highlights={highlights}
+        insertions={insertions}
+      />
+    );
   }
 
   return null;

--- a/frontend-react/src/hooks/useRecorder.ts
+++ b/frontend-react/src/hooks/useRecorder.ts
@@ -12,8 +12,16 @@ const FILLER_AUDIO = "de_zin_was.wav";
 export interface FeedbackData {
   feedback_text: string;
   feedback_audio: string;
-  errors?: { word?: string; expected_word?: string }[];
-  correct?: boolean;
+  reference_text: string;
+  is_correct: boolean;
+  errors: {
+    expected_word: string;
+    heard_word?: string;
+    issue: 'mispronunciation' | 'vowel' | 'consonant' | 'omission' | 'insertion';
+    expected_phonemes?: string;
+    heard_phonemes?: string;
+    letter_errors?: unknown[];
+  }[];
 }
 
 interface RecorderOptions {

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -21,4 +21,13 @@
   .word.wrong {
     @apply bg-red-200 px-1 rounded;
   }
+  .token-error {
+    @apply text-red-600 font-semibold;
+  }
+  .token-correct {
+    @apply text-green-600;
+  }
+  .token-insert-near {
+    @apply underline decoration-dotted decoration-red-500;
+  }
 }

--- a/frontend-react/src/pages/StoryPage.tsx
+++ b/frontend-react/src/pages/StoryPage.tsx
@@ -8,6 +8,7 @@ import { SentenceDisplay } from '@/components/story/SentenceDisplay';
 import type { StoryItem } from '@/components/story/SentenceDisplay';
 import { FeedbackBox } from '@/components/story/FeedbackBox';
 import { RecordControls } from '@/components/story/RecordControls';
+import { buildHighlightMap } from '@/utils/highlight';
 
 export default function StoryPage() {
   const { studentId, teacherId } = useAuthStore();
@@ -16,13 +17,20 @@ export default function StoryPage() {
   const [storyData, setStoryData] = useState<StoryItem[]>([]);
   const [index, setIndex] = useState(0);
   const [feedback, setFeedback] = useState<FeedbackData | null>(null);
+  const [debug, setDebug] = useState(() => localStorage.getItem('debug_json') === '1');
 
   const canvasRef = useRef<HTMLCanvasElement>(null!);
   const currentItem = storyData[index] ?? null;
   const nextItem =
     currentItem?.type === 'direction' ? (storyData[index + 1] ?? null) : null;
 
-  const { recording, status, playbackUrl, startRecording, stopRecording } = useRecorder({
+  const {
+    recording,
+    status,
+    playbackUrl,
+    startRecording: startRec,
+    stopRecording,
+  } = useRecorder({
     sentence: currentItem && currentItem.type === 'sentence' ? currentItem.text : '',
     sentenceAudio:
       currentItem && currentItem.type === 'sentence' ? currentItem.audio : undefined,
@@ -31,6 +39,11 @@ export default function StoryPage() {
     onFeedback: (d) => setFeedback(d),
     canvas: canvasRef.current,
   });
+
+  function startRecording() {
+    setFeedback(null);
+    startRec();
+  }
 
   useEffect(() => {
     const data = localStorage.getItem('story_data');
@@ -63,10 +76,12 @@ export default function StoryPage() {
 
   function next() {
     if (currentItem && currentItem.type === 'direction') return;
+    setFeedback(null);
     setIndex((i) => Math.min(i + 1, storyData.length - 1));
   }
 
   function prev() {
+    setFeedback(null);
     setIndex((i) => Math.max(i - 1, 0));
   }
 
@@ -79,22 +94,47 @@ export default function StoryPage() {
   }
 
   const negative = useMemo(() => {
-    if (!feedback) return false;
-    if (typeof feedback.correct === 'boolean') return !feedback.correct;
-    return /opnieuw|niet gehoord|again|wrong/i.test(feedback.feedback_text);
+    return feedback ? !feedback.is_correct : false;
   }, [feedback]);
 
-  const progress = (index + 1) / storyData.length * 100;
+  const highlights = useMemo(() => {
+    if (!feedback || !currentItem || currentItem.type !== 'sentence')
+      return { map: {}, insertions: [] };
+    return buildHighlightMap(
+      feedback.reference_text || currentItem.text,
+      feedback.errors ?? [],
+      feedback.is_correct,
+    );
+  }, [feedback, currentItem]);
+
+  function toggleDebug() {
+    setDebug((d) => {
+      const nd = !d;
+      localStorage.setItem('debug_json', nd ? '1' : '0');
+      return nd;
+    });
+  }
+
+  const progress = ((index + 1) / storyData.length) * 100;
 
   return (
     <AppShell>
-      <div className="bg-white p-6 mx-auto max-w-xl rounded-xl shadow space-y-4 w-full">
+      <div className="bg-white p-6 mx-auto max-w-xl rounded-xl shadow space-y-4 w-full relative">
+        <button
+          onClick={toggleDebug}
+          className="absolute top-2 right-2 text-slate-500"
+          aria-label="Debug"
+        >
+          <i className="lucide lucide-settings" />
+        </button>
         <label className="font-semibold block text-left" htmlFor="sent">Zin om te lezen:</label>
         <div id="sent" className="bg-white text-[2rem] p-4 rounded-xl shadow text-center">
           <SentenceDisplay
             item={currentItem}
             nextItem={nextItem}
             onDirectionSelect={handleDirection}
+            highlights={highlights.map}
+            insertions={highlights.insertions}
           />
         </div>
         <div className="w-full h-2 bg-slate-200 rounded-full overflow-hidden">
@@ -129,11 +169,23 @@ export default function StoryPage() {
           </button>
         </div>
         <FeedbackBox
-          text={feedback ? feedback.feedback_text.replace(/\*\*(.*?)\*\*/g, '<strong class="highlight">$1</strong>') : ''}
+          text={
+            feedback
+              ? feedback.feedback_text.replace(
+                  /\*\*(.*?)\*\*/g,
+                  '<strong class="highlight">$1</strong>',
+                )
+              : ''
+          }
           negative={negative}
           onReplay={replayFeedback}
           visible={!!feedback}
         />
+        {debug && feedback && (
+          <pre className="mt-4 p-2 bg-slate-100 rounded text-xs overflow-auto">
+            {JSON.stringify(feedback, null, 2)}
+          </pre>
+        )}
       </div>
     </AppShell>
   );

--- a/frontend-react/src/utils/highlight.ts
+++ b/frontend-react/src/utils/highlight.ts
@@ -1,0 +1,60 @@
+export type WordError = {
+  expected_word: string;
+  heard_word?: string;
+  issue: 'mispronunciation' | 'vowel' | 'consonant' | 'omission' | 'insertion';
+  expected_phonemes?: string;
+  heard_phonemes?: string;
+  letter_errors?: unknown[];
+};
+
+export type HighlightResult = {
+  map: Record<number, 'error' | 'correct'>;
+  insertions: number[];
+};
+
+export function normalize(word: string): string {
+  return word
+    .toLowerCase()
+    .replace(/^[^\p{L}\p{N}']+|[^\p{L}\p{N}']+$/gu, '');
+}
+
+export function buildHighlightMap(
+  referenceText: string,
+  errors: WordError[],
+  isCorrect: boolean,
+): HighlightResult {
+  const tokens = referenceText.split(/\s+/);
+  const normTokens = tokens.map(normalize);
+  const available: Record<string, number[]> = {};
+  normTokens.forEach((t, i) => {
+    if (!available[t]) available[t] = [];
+    available[t].push(i);
+  });
+
+  const map: Record<number, 'error' | 'correct'> = {};
+  const insertions: number[] = [];
+  let prevMatched: number | undefined;
+
+  for (const err of errors) {
+    if (err.issue === 'insertion') {
+      insertions.push(prevMatched ?? 0);
+      continue;
+    }
+    const key = normalize(err.expected_word);
+    const idxArr = available[key];
+    if (idxArr && idxArr.length) {
+      const idx = idxArr.shift()!;
+      map[idx] = 'error';
+      prevMatched = idx;
+    }
+  }
+
+  if (isCorrect) {
+    for (let i = 0; i < tokens.length; i++) {
+      if (!map[i]) map[i] = 'correct';
+    }
+  }
+
+  return { map, insertions };
+}
+


### PR DESCRIPTION
## Summary
- Highlight reference sentence words based on backend feedback
- Support red/green feedback pill and debug JSON toggle
- Add utilities and tests for word-level highlight mapping

## Testing
- `cd frontend-react && npm test`
- `cd frontend-react && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898414e87e48327ac9b6ef7ea03c31f