### PR TITLE
Highlight incorrect words in reference sentence

### DIFF
--- a/frontend-react/src/__tests__/highlighting.test.ts
+++ b/frontend-react/src/__tests__/highlighting.test.ts
@@ -1,0 +1,13 @@
+import { buildErrorIndices } from '../utils/highlighting';
+
+test('buildErrorIndices highlights errors using expected_word', () => {
+  const reference = 'foo bar baz';
+  const errors = [{ expected_word: 'bar' }];
+  expect(buildErrorIndices(reference, errors)).toEqual(new Set([1]));
+});
+
+test('buildErrorIndices falls back to word when expected_word is missing', () => {
+  const reference = 'foo bar baz';
+  const errors = [{ word: 'baz' }];
+  expect(buildErrorIndices(reference, errors)).toEqual(new Set([2]));
+});

--- a/frontend-react/src/utils/highlighting.ts
+++ b/frontend-react/src/utils/highlighting.ts
@@ -8,7 +8,7 @@ export function normalize(w: string): string {
 
 export function buildErrorIndices(
   referenceText: string,
-  errors: Array<{ expected_word?: string; issue?: string }>
+  errors: Array<{ expected_word?: string; word?: string; issue?: string }>
 ): Set<number> {
   const tokens = referenceText.split(/\s+/);
   const idxByNorm = new Map<string, number[]>();
@@ -26,7 +26,7 @@ export function buildErrorIndices(
 
   const errorIdx = new Set<number>();
   for (const e of errors || []) {
-    const k = normalize(e.expected_word || '');
+    const k = normalize(e.expected_word || e.word || '');
     const i = takeLeftmost(k);
     if (typeof i === 'number') errorIdx.add(i);
   }


### PR DESCRIPTION
## Summary
- Support legacy `word` field when building error indices for story sentences
- Add tests covering `buildErrorIndices` fallback logic

## Testing
- `cd frontend-react && npm test`
- `cd frontend-react && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689850d35c4c8327b8129859a5570715