### PR TITLE
Reduce stop-to-feedback latency

### DIFF
--- a/webapp/backend/main.py
+++ b/webapp/backend/main.py
@@ -427,6 +427,12 @@ async def realtime_chunk(sid: str, file: UploadFile = File(...)):
 
 @app.post("/api/realtime/stop/{sid}")
 async def realtime_stop(sid: str, request: Request, background: BackgroundTasks):
+    """Stop a realtime session.
+
+    Accepts an optional ``background_tts=1`` query parameter that triggers
+    text-to-speech generation in a background task and immediately returns a
+    JSON response with ``status: 'pending'``.
+    """
     sess = sessions.pop(sid, None)
     if not sess:
         raise HTTPException(status_code=404, detail="Unknown session")


### PR DESCRIPTION
## Summary
- Poll for feedback audio after stop and play as soon as pre-roll ends
- Track new non-negative telemetry metrics for feedback timing
- Document background_tts support in realtime stop endpoint

## Testing
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68989a489d5083279a4ee61b1991a266