### PR TITLE
Reduce feedback latency with async TTS and HEAD polling

### DIFF
--- a/frontend-react/src/components/story/FeedbackBox.tsx
+++ b/frontend-react/src/components/story/FeedbackBox.tsx
@@ -3,6 +3,7 @@ interface FeedbackBoxProps {
   isCorrect: boolean;
   onReplay: () => void;
   visible: boolean;
+  pending?: boolean;
 }
 
 export function FeedbackBox({
@@ -10,6 +11,7 @@ export function FeedbackBox({
   isCorrect,
   onReplay,
   visible,
+  pending,
 }: FeedbackBoxProps) {
   const colorClasses = isCorrect
     ? 'bg-emerald-50 text-emerald-800 border border-emerald-200'
@@ -24,6 +26,12 @@ export function FeedbackBox({
         dangerouslySetInnerHTML={{ __html: text }}
         className="text-left flex-1"
       />
+      {pending && (
+        <div className="flex items-center gap-1 text-sm text-slate-500 mr-2">
+          <i className="lucide lucide-loader-2 animate-spin" />
+          <span>Bezig met feedback…</span>
+        </div>
+      )}
       <button
         onClick={onReplay}
         className="flex items-center gap-1 px-4 py-2 rounded-full bg-primary text-white flex-shrink-0"

--- a/frontend-react/src/pages/StoryPage.tsx
+++ b/frontend-react/src/pages/StoryPage.tsx
@@ -168,6 +168,7 @@ export default function StoryPage() {
           isCorrect={!!isCorrect}
           onReplay={replayFeedback}
           visible={!!feedback}
+          pending={feedback?.status === 'pending'}
         />
       </div>
     </AppShell>


### PR DESCRIPTION
## Summary
- allow HEAD requests for feedback audio and default to background TTS, returning timing metadata
- poll audio readiness via HEAD and play immediately while logging unified metrics
- show pending spinner while feedback audio is still synthesizing

## Testing
- `python -m py_compile webapp/backend/main.py`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898a4daf48c83278329096f5b13d123