### PR TITLE
Add feedback playback timing field to recorder hook

### DIFF
--- a/frontend-react/src/hooks/useRecorder.ts
+++ b/frontend-react/src/hooks/useRecorder.ts
@@ -86,6 +86,7 @@ export function useRecorder({
     stop_to_feedback_ready_ms?: number;
     feedback_ready_to_play_ms?: number;
     stop_to_feedback_play_ms?: number;
+    feedback_playing?: number;
     preroll_start?: number;
     preroll_end?: number;
     sent?: boolean;
@@ -449,7 +450,7 @@ export function useRecorder({
                     });
                     playFeedback();
                     break;
-                  } catch (e) {
+                  } catch {
                     if (controller.signal.aborted) break;
                   }
                 }


### PR DESCRIPTION
## Summary
- track the feedback playback start time via `feedback_playing` in `stopTimingRef`
- clean up unused error variable in retry loop to satisfy lint

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898b92160f88327ab9e10b1aafffe30