### PR TITLE
Make background TTS configurable

### DIFF
--- a/webapp/backend/config.py
+++ b/webapp/backend/config.py
@@ -47,6 +47,10 @@ WORD_VOICE_INSTRUCTIONS = "Spreek in Nederlands"
 # Delay before playing filler sentence after stop (seconds)
 DELAY_SECONDS = 0.5
 
+# Run text-to-speech generation in a background task by default.  When set to
+# ``False`` the realtime API waits for TTS to complete before responding.
+BACKGROUND_TTS = os.getenv("BACKGROUND_TTS", "true").lower() not in {"0", "false", "no"}
+
 # Overall pipeline mode: when ``False`` the backend expects a single WAV file
 # instead of realtime chunks.
 REALTIME = os.getenv("REALTIME", "true").lower() not in {"0", "false", "no"}

--- a/webapp/backend/main.py
+++ b/webapp/backend/main.py
@@ -468,7 +468,7 @@ async def realtime_stop(sid: str, request: Request, background: BackgroundTasks)
     feedback_dest = storage.STORAGE_DIR / feedback_name
 
     q = request.query_params.get("background_tts")
-    background_tts = True if q is None else q in {"1", "true", "yes"}
+    background_tts = config.BACKGROUND_TTS if q is None else q in {"1", "true", "yes"}
 
     if background_tts:
         background.add_task(_tts_background, tutor_resp.feedback_text, feedback_dest, results, sess.timeline)


### PR DESCRIPTION
## Summary
- Add `BACKGROUND_TTS` option in backend config so the realtime API can run TTS in the foreground when desired
- Honor this setting in `/api/realtime/stop` when the query parameter is absent

## Testing
- `python -m py_compile webapp/backend/config.py webapp/backend/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6898c0f6910883279500fd3fb0db4581