### PR TITLE
Stabilize realtime stop and chunk teardown

### DIFF
--- a/frontend-react/src/components/story/RecordControls.tsx
+++ b/frontend-react/src/components/story/RecordControls.tsx
@@ -6,6 +6,7 @@ interface RecordControlsProps {
   onPlayback: () => void;
   status: string;
   canvasRef: React.RefObject<HTMLCanvasElement>;
+  canStop: boolean;
 }
 
 export function RecordControls({
@@ -16,6 +17,7 @@ export function RecordControls({
   onPlayback,
   status,
   canvasRef,
+  canStop,
 }: RecordControlsProps) {
   return (
     <div className="flex flex-col items-center mt-4">
@@ -28,7 +30,8 @@ export function RecordControls({
         />
         <button
           onClick={recording ? onStop : onRecord}
-          className={`w-28 h-28 rounded-full flex flex-col items-center justify-center bg-primary text-white ${recording ? "shadow-inner" : ""}`}
+          disabled={recording && !canStop}
+          className={`w-28 h-28 rounded-full flex flex-col items-center justify-center bg-primary text-white ${recording ? "shadow-inner" : ""} disabled:opacity-50`}
         >
           <i className="lucide lucide-mic text-4xl" />
           <span className="label mt-1 text-sm">

--- a/frontend-react/src/pages/StoryPage.tsx
+++ b/frontend-react/src/pages/StoryPage.tsx
@@ -33,6 +33,7 @@ export default function StoryPage() {
     playbackUrl,
     startRecording: recorderStart,
     stopRecording: recorderStop,
+    canStop,
   } = useRecorder({
     sentence: sentenceText,
     sentenceAudio:
@@ -138,6 +139,7 @@ export default function StoryPage() {
             onPlayback={playRecorded}
             status={status}
             canvasRef={canvasRef}
+            canStop={canStop}
           />
         )}
         <div className="flex justify-between mt-4">


### PR DESCRIPTION
## Summary
- Guard stopRecording when no session ID and log session state
- Stop chunk uploads during shutdown and swallow expected 404s
- Expose session-ready flag to disable Stop button until backend start succeeds

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899db6a93fc832793a9960e10bc03ca