### PR TITLE
Preload sentence audio for smoother pre-roll

### DIFF
--- a/frontend-react/src/pages/StoryPage.tsx
+++ b/frontend-react/src/pages/StoryPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import AppShell from '@/components/layout/AppShell';
 import { useAuthStore } from '@/lib/useAuthStore';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { useRecorder } from '@/hooks/useRecorder';
+import { useRecorder, preloadAudios } from '@/hooks/useRecorder';
 import type { FeedbackData } from '@/hooks/useRecorder';
 import { SentenceDisplay } from '@/components/story/SentenceDisplay';
 import type { StoryItem } from '@/components/story/SentenceDisplay';
@@ -55,7 +55,11 @@ export default function StoryPage() {
       return;
     }
     try {
-      setStoryData(JSON.parse(data));
+      const parsed: StoryItem[] = JSON.parse(data);
+      setStoryData(parsed);
+      preloadAudios(
+        parsed.filter((i) => i.type === 'sentence').map((i) => i.audio),
+      );
       const idx = Number(localStorage.getItem('story_index'));
       if (!Number.isNaN(idx)) {
         setIndex(idx);


### PR DESCRIPTION
## Summary
- preload sentence audio files and track readiness
- wait for filler and sentence clips before starting pre-roll playback
- trigger sentence audio preload when story data loads

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689af50d55bc8327b0d075807775ccbb