### PR TITLE
fix: import TutorPhase as type in RecordControls

### DIFF
--- a/frontend-react/src/components/story/RecordControls.tsx
+++ b/frontend-react/src/components/story/RecordControls.tsx
@@ -1,4 +1,4 @@
-import { TutorPhase } from '@/hooks/useRecorder';
+import type { TutorPhase } from '@/hooks/useRecorder';
 import { ShimmerText } from '../ShimmerText';
 
 interface RecordControlsProps {


### PR DESCRIPTION
## Summary
- fix type-only import for TutorPhase in RecordControls

## Testing
- `npm run build`
- `python -m uvicorn webapp.backend.main:app --reload --no-access-log` *(fails: No module named 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_689b31ec5f208327a9b1b7d61b21274b