### PR TITLE
feat: slow left-to-right shimmer

### DIFF
--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -21,24 +21,29 @@
   .word.wrong {
     @apply bg-red-200 px-1 rounded;
   }
-  @keyframes shimmer {
-    0% {
-      background-position: -200% 0;
-    }
-    100% {
-      background-position: 200% 0;
-    }
+  @keyframes shimmer-ltr {
+    0%   { background-position: -200% 0; }
+    100% { background-position: 200% 0; }
   }
+
   .animate-shimmer {
-    @apply bg-clip-text;
-    -webkit-text-fill-color: transparent;
+    --shimmer-speed: 2200ms; /* slower sweep; tweak 2000–2600ms if needed */
     background-image: linear-gradient(
       90deg,
-      currentColor 8%,
-      rgba(255, 255, 255, 0.35) 18%,
-      currentColor 33%
+      currentColor 0%,
+      rgba(255,255,255,0.35) 18%,
+      currentColor 36%
     );
     background-size: 200% 100%;
-    animation: shimmer 1.25s linear infinite;
+    background-repeat: no-repeat;
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    animation: shimmer-ltr var(--shimmer-speed) linear infinite;
   }
+}
+
+/* Respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .animate-shimmer { animation: none; color: inherit; }
 }


### PR DESCRIPTION
## Summary
- Adjust shimmer animation to move left-to-right at a slower speed
- Respect reduced-motion preferences by disabling shimmer animation

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b3c9f2ebc8327ae8b9336f048bf1f