### PR TITLE
Fix shimmer status text visibility

### DIFF
--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -38,12 +38,15 @@
     background-repeat: no-repeat;
     -webkit-background-clip: text;
     background-clip: text;
-    color: transparent;
+    -webkit-text-fill-color: transparent;
     animation: shimmer-ltr var(--shimmer-speed) linear infinite;
   }
 }
 
 /* Respect reduced motion */
 @media (prefers-reduced-motion: reduce) {
-  .animate-shimmer { animation: none; color: inherit; }
+  .animate-shimmer {
+    animation: none;
+    -webkit-text-fill-color: inherit;
+  }
 }


### PR DESCRIPTION
## Summary
- ensure status labels remain visible by removing transparent color in shimmer effect and using `-webkit-text-fill-color`
- respect reduced-motion setting without hiding text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b41c5c1188327b0c7ac908fff3771