### PR TITLE
Refine shimmer utility for slow left-to-right sweep

### DIFF
--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -23,30 +23,36 @@
   }
   @keyframes shimmer-ltr {
     0%   { background-position: -200% 0; }
-    100% { background-position: 200% 0; }
+    100% { background-position:  200% 0; }
   }
 
   .animate-shimmer {
-    --shimmer-speed: 2200ms; /* slower sweep; tweak 2000–2600ms if needed */
+    --shimmer-speed: 2200ms; /* tweak ~2000–2600ms if needed */
+    color: inherit; /* keep currentColor available for the gradient */
+
     background-image: linear-gradient(
       90deg,
       currentColor 0%,
-      rgba(255,255,255,0.35) 18%,
+      rgba(255,255,255,.35) 18%,
       currentColor 36%
     );
     background-size: 200% 100%;
     background-repeat: no-repeat;
+
     -webkit-background-clip: text;
     background-clip: text;
+
+    /* hide the fill, keep color for currentColor */
     -webkit-text-fill-color: transparent;
+
     animation: shimmer-ltr var(--shimmer-speed) linear infinite;
   }
 }
 
-/* Respect reduced motion */
 @media (prefers-reduced-motion: reduce) {
   .animate-shimmer {
     animation: none;
-    -webkit-text-fill-color: inherit;
+    background-image: none;
+    -webkit-text-fill-color: currentColor; /* show normal text */
   }
 }


### PR DESCRIPTION
## Summary
- keep glyph color inherited while hiding fill for gradient-driven shimmer
- honor prefers-reduced-motion by disabling animation and gradient, revealing text

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b44d45ab0832782f0e8557806ce4a