### PR TITLE
fix: stabilize shimmer animation

### DIFF
--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -21,14 +21,14 @@
   .word.wrong {
     @apply bg-red-200 px-1 rounded;
   }
-  @keyframes shimmer-ltr {
-    0%   { background-position: -200% 0; }
-    100% { background-position:  200% 0; }
+  @keyframes shimmer-ltr-stable {
+    0%   { background-position: -100% 0; }
+    100% { background-position:  100% 0; }
   }
 
   .animate-shimmer {
-    --shimmer-speed: 2200ms; /* tweak ~2000–2600ms if needed */
-    color: inherit; /* keep currentColor available for the gradient */
+    --shimmer-speed: 2200ms; /* adjust 2000–2600ms if needed */
+    color: inherit;
 
     background-image: linear-gradient(
       90deg,
@@ -36,16 +36,14 @@
       rgba(255,255,255,.35) 18%,
       currentColor 36%
     );
-    background-size: 200% 100%;
+    background-size: 300% 100%;      /* wider so gradient never fully leaves */
     background-repeat: no-repeat;
 
     -webkit-background-clip: text;
     background-clip: text;
-
-    /* hide the fill, keep color for currentColor */
     -webkit-text-fill-color: transparent;
 
-    animation: shimmer-ltr var(--shimmer-speed) linear infinite;
+    animation: shimmer-ltr-stable var(--shimmer-speed) linear infinite;
   }
 }
 


### PR DESCRIPTION
## Summary
- widen shimmer gradient and adjust animation so text stays visible
- maintain base color with `color: inherit` and hide fill via `-webkit-text-fill-color: transparent`
- preserve reduced-motion fallback

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b48ade4f08327ae79600fb7dde9b6