### PR TITLE
Fix shimmer overlay to avoid blinking

### DIFF
--- a/frontend-react/src/components/ShimmerText.tsx
+++ b/frontend-react/src/components/ShimmerText.tsx
@@ -18,9 +18,18 @@ export function ShimmerText({
       role="status"
       aria-busy={active}
       aria-live={ariaLive ?? 'polite'}
-      className={cn(className, active && 'animate-shimmer')}
+      className={cn('relative inline-block align-baseline', className)}
     >
-      {text}
+      <span>{text}</span>
+      <span
+        aria-hidden="true"
+        className={cn(
+          'absolute inset-0 pointer-events-none select-none',
+          active && 'animate-shimmer'
+        )}
+      >
+        {text}
+      </span>
     </span>
   );
 }

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -22,26 +22,28 @@
     @apply bg-red-200 px-1 rounded;
   }
   @keyframes shimmer-ltr-stable {
-    0%   { background-position: -100% 0; }
-    100% { background-position:  100% 0; }
+    0%   { background-position: -60% 0; }
+    100% { background-position: 160% 0; }
   }
 
   .animate-shimmer {
     --shimmer-speed: 2200ms; /* adjust 2000–2600ms if needed */
+    display: inline-block;
+    will-change: background-position;
     color: inherit;
 
     background-image: linear-gradient(
       90deg,
       currentColor 0%,
-      rgba(255,255,255,.35) 18%,
+      rgba(255,255,255,0.35) 18%,
       currentColor 36%
     );
-    background-size: 300% 100%;      /* wider so gradient never fully leaves */
+    background-size: 260% 100%;         /* wide so it never fully leaves */
     background-repeat: no-repeat;
 
     -webkit-background-clip: text;
     background-clip: text;
-    -webkit-text-fill-color: transparent;
+    -webkit-text-fill-color: transparent; /* only on overlay, not base text */
 
     animation: shimmer-ltr-stable var(--shimmer-speed) linear infinite;
   }


### PR DESCRIPTION
## Summary
- render status text with static layer plus animated overlay to prevent disappearing text
- tweak shimmer keyframes and animation styling for smooth left-to-right sweep

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b4b992ef88327b116d3aa31d77107