### PR TITLE
Add decodable story generator and early reading content rails

### DIFF
--- a/frontend-react/src/__tests__/decodability.mastery.test.ts
+++ b/frontend-react/src/__tests__/decodability.mastery.test.ts
@@ -1,0 +1,37 @@
+import { isDecodable } from '@/lib/decodability';
+import { MasteryTracker } from '@/lib/mastery';
+import { CONTENT_CONFIG } from '@/lib/contentConfig';
+
+test('decodability rejects disallowed digraph', () => {
+  const unit = CONTENT_CONFIG.levels[0].units[0];
+  const allowed = unit.focus_phonemes;
+  expect(
+    isDecodable('ik speel ui.', allowed, unit.allowed_patterns, unit.sentence_rules.max_words),
+  ).toBe(false);
+});
+
+test('decodability enforces word limit', () => {
+  const unit = CONTENT_CONFIG.levels[0].units[3]; // unit D
+  const allowed = CONTENT_CONFIG.levels[0].units
+    .slice(0, 4)
+    .flatMap((u) => u.focus_phonemes);
+  const longSentence = 'huis weg bos tak hut boom';
+  expect(
+    isDecodable(
+      longSentence,
+      allowed,
+      unit.allowed_patterns,
+      unit.sentence_rules.max_words,
+    ),
+  ).toBe(false);
+});
+
+test('mastery unlocks after consecutive accurate sessions', () => {
+  const unit = CONTENT_CONFIG.levels[0].units[0];
+  const tracker = new MasteryTracker({ accuracy: 0.93, sessions: 2 });
+  tracker.record(unit, 0.95);
+  expect(tracker.isMastered(unit)).toBe(false);
+  tracker.record(unit, 0.94);
+  expect(tracker.isMastered(unit)).toBe(true);
+});
+

--- a/frontend-react/src/lib/contentConfig.ts
+++ b/frontend-react/src/lib/contentConfig.ts
@@ -1,0 +1,276 @@
+// Content configuration and types for Dutch early reading track
+// Defines levels and units with phoneme focus, patterns, and mastery rules
+
+export type TrackId = 'AVI';
+
+export type UnitId =
+  | 'A'
+  | 'B'
+  | 'C'
+  | 'D'
+  | 'E'
+  | 'F'
+  | 'G'
+  | 'H'
+  | 'I'
+  | 'J'
+  | 'K'
+  | 'L';
+
+export interface SentenceRules {
+  present: boolean; // always true
+  max_words: number;
+  punctuation: 'period_only';
+  allow_names: boolean;
+}
+
+export interface MasteryThresholds {
+  accuracy: number;
+  sessions: number;
+  pace_wcpm?: number;
+}
+
+export interface UnitSpec {
+  id: UnitId;
+  label: string;
+  focus_phonemes: string[];
+  allowed_patterns: string[];
+  word_bank: string[];
+  sentence_rules: SentenceRules;
+  starts_sentences: boolean;
+  mastery_thresholds: MasteryThresholds;
+}
+
+export interface LevelSpec {
+  id: 'AVI-Start' | 'AVI-M3' | 'AVI-E3' | 'AVI-M4' | 'AVI-E4';
+  label: string;
+  units: UnitSpec[];
+  defaults: { mastery: MasteryThresholds };
+}
+
+export interface ContentConfig {
+  track: TrackId;
+  levels: LevelSpec[];
+}
+
+export const CONTENT_CONFIG: ContentConfig = {
+  track: 'AVI',
+  levels: [
+    {
+      id: 'AVI-Start',
+      label: 'AVI Start',
+      defaults: { mastery: { accuracy: 0.93, sessions: 2, pace_wcpm: 35 } },
+      units: [
+        {
+          id: 'A',
+          label: 'A',
+          focus_phonemes: ['m', 'r', 'v', 'i', 's', 'aa', 'p', 'e'],
+          allowed_patterns: ['CV', 'CVC'],
+          word_bank: ['ik', 'maan', 'roos', 'vis', 'pen', 'aan', 'en', 'sok'],
+          sentence_rules: {
+            present: true,
+            max_words: 6,
+            punctuation: 'period_only',
+            allow_names: true,
+          },
+          starts_sentences: false,
+          mastery_thresholds: { accuracy: 0.93, sessions: 2 },
+        },
+        {
+          id: 'B',
+          label: 'B',
+          focus_phonemes: ['t', 'n', 'b', 'oo', 'ee'],
+          allowed_patterns: ['CV', 'CVC', 'CVCC'],
+          word_bank: ['teen', 'een', 'neus', 'buik', 'oog'],
+          sentence_rules: {
+            present: true,
+            max_words: 6,
+            punctuation: 'period_only',
+            allow_names: true,
+          },
+          starts_sentences: false,
+          mastery_thresholds: { accuracy: 0.93, sessions: 2 },
+        },
+        {
+          id: 'C',
+          label: 'C',
+          focus_phonemes: ['d', 'oe', 'k', 'ij', 'z'],
+          allowed_patterns: ['CV', 'CVC', 'CVCC'],
+          word_bank: ['doos', 'poes', 'koek', 'ijs', 'zeep'],
+          sentence_rules: {
+            present: true,
+            max_words: 6,
+            punctuation: 'period_only',
+            allow_names: true,
+          },
+          starts_sentences: false,
+          mastery_thresholds: { accuracy: 0.93, sessions: 2 },
+        },
+        {
+          id: 'D',
+          label: 'D',
+          focus_phonemes: ['h', 'w', 'o', 'a', 'u'],
+          allowed_patterns: ['CV', 'CVC', 'CVCC'],
+          word_bank: ['huis', 'weg', 'bos', 'tak', 'hut'],
+          sentence_rules: {
+            present: true,
+            max_words: 7,
+            punctuation: 'period_only',
+            allow_names: true,
+          },
+          starts_sentences: true,
+          mastery_thresholds: { accuracy: 0.93, sessions: 2 },
+        },
+        {
+          id: 'E',
+          label: 'E',
+          focus_phonemes: ['eu', 'j', 'ie', 'l', 'ou', 'uu'],
+          allowed_patterns: ['CV', 'CVC', 'CVCC', 'CCVC'],
+          word_bank: ['reus', 'jas', 'riem', 'bijl', 'hout', 'vuur'],
+          sentence_rules: {
+            present: true,
+            max_words: 7,
+            punctuation: 'period_only',
+            allow_names: true,
+          },
+          starts_sentences: true,
+          mastery_thresholds: { accuracy: 0.93, sessions: 2 },
+        },
+        {
+          id: 'F',
+          label: 'F',
+          focus_phonemes: ['g', 'ui', 'au', 'f', 'ei'],
+          allowed_patterns: ['CV', 'CVC', 'CVCC', 'CCVC'],
+          word_bank: ['geit', 'pauw', 'duif', 'ei'],
+          sentence_rules: {
+            present: true,
+            max_words: 7,
+            punctuation: 'period_only',
+            allow_names: true,
+          },
+          starts_sentences: true,
+          mastery_thresholds: { accuracy: 0.93, sessions: 2 },
+        },
+        {
+          id: 'G',
+          label: 'G',
+          focus_phonemes: ['sch', 'ng'],
+          allowed_patterns: ['CV', 'CVC', 'CCVC', 'CVCC'],
+          word_bank: ['kist', 'drop', 'hond', 'slang', 'bank', 'springt', 'meeuw', 'ja', 'zo'],
+          sentence_rules: {
+            present: true,
+            max_words: 8,
+            punctuation: 'period_only',
+            allow_names: true,
+          },
+          starts_sentences: true,
+          mastery_thresholds: { accuracy: 0.93, sessions: 2 },
+        },
+        {
+          id: 'H',
+          label: 'H',
+          focus_phonemes: ['nk', 'ch'],
+          allowed_patterns: ['CV', 'CVC', 'CCVC', 'CVCC'],
+          word_bank: ['bank', 'licht'],
+          sentence_rules: {
+            present: true,
+            max_words: 8,
+            punctuation: 'period_only',
+            allow_names: true,
+          },
+          starts_sentences: true,
+          mastery_thresholds: { accuracy: 0.93, sessions: 2 },
+        },
+        {
+          id: 'I',
+          label: 'I',
+          focus_phonemes: ['aai', 'ooi', 'oei'],
+          allowed_patterns: ['CV', 'CVC', 'CCVC', 'CVCC'],
+          word_bank: ['kraai', 'kooi', 'groei'],
+          sentence_rules: {
+            present: true,
+            max_words: 8,
+            punctuation: 'period_only',
+            allow_names: true,
+          },
+          starts_sentences: true,
+          mastery_thresholds: { accuracy: 0.93, sessions: 2 },
+        },
+        {
+          id: 'J',
+          label: 'J',
+          focus_phonemes: ['ieuw', 'eeuw', 'uw'],
+          allowed_patterns: ['CV', 'CVC', 'CCVC', 'CVCC'],
+          word_bank: ['nieuw', 'leeuw', 'uw'],
+          sentence_rules: {
+            present: true,
+            max_words: 9,
+            punctuation: 'period_only',
+            allow_names: true,
+          },
+          starts_sentences: true,
+          mastery_thresholds: { accuracy: 0.93, sessions: 2 },
+        },
+        {
+          id: 'K',
+          label: 'K',
+          focus_phonemes: ['vr', 'sl', '-lijk', '-tig', '-ing'],
+          allowed_patterns: ['CV', 'CVC', 'CCVC', 'CVCC'],
+          word_bank: ['vragen', 'spelen', 'schotel', 'sturen', 'moeilijk', 'koning'],
+          sentence_rules: {
+            present: true,
+            max_words: 9,
+            punctuation: 'period_only',
+            allow_names: true,
+          },
+          starts_sentences: true,
+          mastery_thresholds: { accuracy: 0.93, sessions: 2 },
+        },
+        {
+          id: 'L',
+          label: 'L',
+          focus_phonemes: ['consolideer'],
+          allowed_patterns: ['CV', 'CVC', 'CCVC', 'CVCC'],
+          word_bank: [],
+          sentence_rules: {
+            present: true,
+            max_words: 9,
+            punctuation: 'period_only',
+            allow_names: true,
+          },
+          starts_sentences: true,
+          mastery_thresholds: { accuracy: 0.93, sessions: 2 },
+        },
+      ],
+    },
+    {
+      id: 'AVI-M3',
+      label: 'AVI M3',
+      defaults: { mastery: { accuracy: 0.94, sessions: 2, pace_wcpm: 45 } },
+      units: [],
+    },
+    {
+      id: 'AVI-E3',
+      label: 'AVI E3',
+      defaults: { mastery: { accuracy: 0.95, sessions: 2, pace_wcpm: 60 } },
+      units: [],
+    },
+    {
+      id: 'AVI-M4',
+      label: 'AVI M4',
+      defaults: { mastery: { accuracy: 0.95, sessions: 2, pace_wcpm: 75 } },
+      units: [],
+    },
+    {
+      id: 'AVI-E4',
+      label: 'AVI E4',
+      defaults: { mastery: { accuracy: 0.96, sessions: 2, pace_wcpm: 90 } },
+      units: [],
+    },
+  ],
+};
+
+export function loadContentConfig(): ContentConfig {
+  return CONTENT_CONFIG;
+}
+

--- a/frontend-react/src/lib/decodability.ts
+++ b/frontend-react/src/lib/decodability.ts
@@ -1,0 +1,128 @@
+// Utilities to check Dutch decodability and build simple fallbacks
+
+import type { UnitSpec } from './contentConfig';
+
+const DIGRAPHS = [
+  'aai',
+  'ooi',
+  'oei',
+  'ieuw',
+  'eeuw',
+  'sch',
+  'ng',
+  'nk',
+  'ch',
+  'ij',
+  'oe',
+  'ui',
+  'eu',
+  'ei',
+  'ie',
+  'ou',
+  'au',
+  'uw',
+];
+
+const VOWELS = new Set([
+  'a',
+  'e',
+  'i',
+  'o',
+  'u',
+  'aa',
+  'ee',
+  'oo',
+  'eu',
+  'ie',
+  'ij',
+  'oe',
+  'ui',
+  'ou',
+  'au',
+  'ei',
+  'aai',
+  'ooi',
+  'oei',
+  'ieuw',
+  'eeuw',
+  'uw',
+]);
+
+export function parseGraphemes(text: string): string[] {
+  const lower = text.toLowerCase();
+  const result: string[] = [];
+  let i = 0;
+  while (i < lower.length) {
+    let match = '';
+    for (const d of DIGRAPHS) {
+      if (lower.startsWith(d, i)) {
+        match = d;
+        break;
+      }
+    }
+    if (match) {
+      result.push(match);
+      i += match.length;
+    } else {
+      const ch = lower[i];
+      result.push(ch);
+      i += 1;
+    }
+  }
+  return result;
+}
+
+function patternOfWord(word: string): string {
+  const gs = parseGraphemes(word);
+  return gs
+    .map((g) => (VOWELS.has(g) ? 'V' : g === '-' ? '-' : 'C'))
+    .join('');
+}
+
+export function isDecodable(
+  text: string,
+  allowedGraphemes: string[],
+  allowedPatterns: string[],
+  maxWords: number,
+): boolean {
+  const words = text.trim().split(/\s+/);
+  if (words.length > maxWords) return false;
+  const allowed = new Set(allowedGraphemes.map((g) => g.toLowerCase()));
+  for (const w of words) {
+    const clean = w.replace(/[.]/g, '');
+    const gs = parseGraphemes(clean);
+    for (const g of gs) {
+      if (!allowed.has(g)) return false;
+    }
+    const pattern = patternOfWord(clean);
+    if (!allowedPatterns.includes(pattern)) return false;
+  }
+  return true;
+}
+
+const FALLBACK_NAMES = ['Sam', 'Rik', 'Mia', 'Noor', 'Lila', 'Pim'];
+const FALLBACK_VERBS = ['ziet', 'heeft', 'pakt', 'maakt'];
+
+function pickDecodable(
+  list: string[],
+  allowed: string[],
+): string | undefined {
+  return list.find((w) => isDecodable(w, allowed, ['CV', 'CVC', 'CVCC', 'CCVC'], 1));
+}
+
+export function buildFallback(unit: UnitSpec, allowed: string[]): {
+  sentences: string[];
+  directions: string[];
+} {
+  const name = pickDecodable(FALLBACK_NAMES, allowed) ?? 'Sam';
+  const sentences: string[] = [];
+  for (let i = 0; i < 5; i++) {
+    const verb = pickDecodable(FALLBACK_VERBS, allowed) ?? 'ziet';
+    const obj = unit.word_bank[i % unit.word_bank.length] ?? name.toLowerCase();
+    const s = `${name} ${verb} ${obj}.`;
+    sentences.push(s);
+  }
+  const directions = ['ga door', 'ga terug'];
+  return { sentences, directions };
+}
+

--- a/frontend-react/src/lib/mastery.ts
+++ b/frontend-react/src/lib/mastery.ts
@@ -1,0 +1,45 @@
+// Simple mastery and adaptivity tracking
+
+import type { MasteryThresholds, UnitSpec } from './contentConfig';
+
+export class MasteryTracker {
+  private records: Record<string, number[]> = {};
+  private thresholds: MasteryThresholds;
+  constructor(thresholds: MasteryThresholds) {
+    this.thresholds = thresholds;
+  }
+
+  record(unit: UnitSpec, accuracy: number) {
+    const key = unit.id;
+    const arr = this.records[key] || [];
+    arr.push(accuracy);
+    const { sessions } = unit.mastery_thresholds || this.thresholds;
+    this.records[key] = arr.slice(-sessions);
+  }
+
+  isMastered(unit: UnitSpec): boolean {
+    const t = unit.mastery_thresholds || this.thresholds;
+    const arr = this.records[unit.id] || [];
+    if (arr.length < t.sessions) return false;
+    return arr.every((v) => v >= t.accuracy);
+  }
+}
+
+export class MistakeProfile {
+  private ema: Record<string, number> = {};
+  private readonly alpha = 0.3;
+
+  record(phoneme: string, correct: boolean) {
+    const prev = this.ema[phoneme] ?? 0;
+    const val = correct ? 0 : 1;
+    this.ema[phoneme] = prev * (1 - this.alpha) + val * this.alpha;
+  }
+
+  weak(threshold = 0.15): string[] {
+    return Object.entries(this.ema)
+      .filter(([, v]) => v > threshold)
+      .map(([k]) => k)
+      .slice(0, 2);
+  }
+}
+

--- a/frontend-react/src/lib/storyGenerator.ts
+++ b/frontend-react/src/lib/storyGenerator.ts
@@ -1,0 +1,152 @@
+// Story generation service using OpenAI with strict schema and decodability guard
+
+import OpenAI from 'openai';
+import type { UnitSpec, LevelSpec } from './contentConfig';
+import { isDecodable, buildFallback } from './decodability';
+
+const SYSTEM_MESSAGE = `Je bent een Nederlandse verhalenmaker voor beginnende lezers (4–8 jaar).
+Stijl en regels (STRIKT):
+• Toon: warm, veilig, eenvoudig. Tijd: tegenwoordige tijd.
+• Zinnen: kort en concreet, 4–9 woorden (later max 12).
+• Interpunctie: alleen een punt (.) aan het einde van elke zin.
+• Woorden: veelvoorkomende, decodabele woorden passend bij de opgegeven klanken/patronen.
+• Namen zijn toegestaan (eenvoudig), maar houd het perspectief binnen dit verhaal consistent.
+• Geen aanhalingstekens, geen cijfers, geen moeilijke vaktermen.
+• Mini-scène per beurt: (1) start, (2–3) kleine stappen, (4) gevolg, (5) zacht spanningspunt.
+
+Uitvoer (STRIKT JSON):
+{
+  "sentences": [vijf zinnen],
+  "directions": [twee keuzes, gebiedende wijs, 2–4 woorden]
+}
+Geen extra tekst, geen uitleg, geen markdown.`;
+
+const SCHEMA = {
+  type: 'json_schema',
+  json_schema: {
+    name: 'ContinueStory',
+    schema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        sentences: {
+          type: 'array',
+          minItems: 5,
+          maxItems: 5,
+          items: { type: 'string', minLength: 3, maxLength: 120 },
+        },
+        directions: {
+          type: 'array',
+          minItems: 2,
+          maxItems: 2,
+          items: { type: 'string', minLength: 2, maxLength: 60 },
+        },
+      },
+      required: ['sentences', 'directions'],
+    },
+  },
+} as const;
+
+export interface GenerateOptions {
+  theme: string;
+  level: LevelSpec;
+  unit: UnitSpec;
+  allowedGraphemes: string[];
+  storySoFar?: string;
+  focus?: string[];
+  temperature?: number;
+}
+
+export async function generateTurn({
+  theme,
+  level,
+  unit,
+  allowedGraphemes,
+  storySoFar,
+  focus,
+  temperature = 0.2,
+}: GenerateOptions) {
+  const userPrompt = buildUserPrompt({
+    theme,
+    levelId: level.id,
+    unitId: unit.id,
+    allowedGraphemes,
+    allowedPatterns: unit.allowed_patterns,
+    maxWords: unit.sentence_rules.max_words,
+    storySoFar,
+    focus,
+  });
+
+  const client = new OpenAI();
+
+  async function callModel() {
+    const res = await client.responses.parse({
+      model: 'gpt-4.1-mini',
+      temperature,
+      max_output_tokens: 300,
+      input: [
+        { role: 'system', content: SYSTEM_MESSAGE },
+        { role: 'user', content: userPrompt },
+      ],
+      response_format: SCHEMA,
+    });
+    return res.output[0]?.content[0]?.text;
+  }
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const json = await callModel();
+      if (!json) throw new Error('empty response');
+      const data = JSON.parse(json) as {
+        sentences: string[];
+        directions: string[];
+      };
+      const ok = [...data.sentences, ...data.directions].every((s) =>
+        isDecodable(s, allowedGraphemes, unit.allowed_patterns, unit.sentence_rules.max_words),
+      );
+      if (ok) return data;
+    } catch {
+      /* ignore */
+    }
+  }
+  return buildFallback(unit, allowedGraphemes);
+}
+
+function buildUserPrompt(opts: {
+  theme: string;
+  levelId: string;
+  unitId: string;
+  allowedGraphemes: string[];
+  allowedPatterns: string[];
+  maxWords: number;
+  storySoFar?: string;
+  focus?: string[];
+}): string {
+  const {
+    theme,
+    levelId,
+    unitId,
+    allowedGraphemes,
+    allowedPatterns,
+    maxWords,
+    storySoFar,
+    focus,
+  } = opts;
+  const parts = [
+    `Thema: ${theme}`,
+    `Niveau: ${levelId}  Eenheid: ${unitId}`,
+    `Toegestane klanken/letters: ${allowedGraphemes.join(', ')}`,
+    `Toegestane patronen: ${allowedPatterns.join(', ')}`,
+    `Maximale woorden per zin: ${maxWords}`,
+  ];
+  if (storySoFar) parts.push(`Verhaalsamenvatting tot nu toe: "${storySoFar}"`);
+  if (focus && focus.length)
+    parts.push(`Focus (optioneel): ${focus.join(', ')}`);
+  parts.push(
+    'Schrijf vijf korte, decodabele zinnen die logisch doorgaan.',
+  );
+  parts.push('Gebruik alleen toegestane klanken/patronen; vermijd andere klanken.');
+  parts.push('Geef precies twee korte keuzes (gebiedende wijs, 2–4 woorden).');
+  return parts.join('\n');
+}
+

--- a/frontend-react/src/main.tsx
+++ b/frontend-react/src/main.tsx
@@ -11,6 +11,10 @@ import ProgressPage from './pages/ProgressPage';
 import RequireAuth from './components/RequireAuth';
 import StoryPage from './pages/StoryPage';
 import ContinuePage from './pages/ContinuePage';
+import SelectLevelPage from './pages/SelectLevelPage';
+import SelectUnitPage from './pages/SelectUnitPage';
+import SessionPage from './pages/SessionPage';
+import ResultsPage from './pages/ResultsPage';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
@@ -25,6 +29,10 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
             <Route path="/story" element={<StoryPage />} />
             <Route path="/continue" element={<ContinuePage />} />
             <Route path="/progress" element={<ProgressPage />} />
+            <Route path="/levels" element={<SelectLevelPage />} />
+            <Route path="/units/:levelId" element={<SelectUnitPage />} />
+            <Route path="/session/:levelId/:unitId" element={<SessionPage />} />
+            <Route path="/results" element={<ResultsPage />} />
           </Route>
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>

--- a/frontend-react/src/pages/ResultsPage.tsx
+++ b/frontend-react/src/pages/ResultsPage.tsx
@@ -1,0 +1,33 @@
+import AppShell from '@/components/layout/AppShell';
+import { Link, useLocation } from 'react-router-dom';
+
+function useQuery() {
+  const { search } = useLocation();
+  return new URLSearchParams(search);
+}
+
+export default function ResultsPage() {
+  const q = useQuery();
+  const accuracy = Number(q.get('accuracy') || 0);
+  const pace = Number(q.get('pace') || 0);
+  const weak = q.get('weak')?.split(',').filter(Boolean) || [];
+  return (
+    <AppShell>
+      <div className="max-w-md w-full space-y-4 text-center">
+        <h2 className="text-xl font-title">Resultaat</h2>
+        <p>Nauwkeurigheid: {Math.round(accuracy * 100)}%</p>
+        <p>Tempo: {pace} wpm</p>
+        {weak.length > 0 && <p>Zwakke klanken: {weak.join(', ')}</p>}
+        <div className="flex justify-center gap-4">
+          <Link to="/" className="px-3 py-1 bg-primary text-white rounded">
+            Herhaal
+          </Link>
+          <Link to="/levels" className="px-3 py-1 bg-primary text-white rounded">
+            Volgende
+          </Link>
+        </div>
+      </div>
+    </AppShell>
+  );
+}
+

--- a/frontend-react/src/pages/SelectLevelPage.tsx
+++ b/frontend-react/src/pages/SelectLevelPage.tsx
@@ -1,0 +1,27 @@
+import AppShell from '@/components/layout/AppShell';
+import { loadContentConfig } from '@/lib/contentConfig';
+import { Link } from 'react-router-dom';
+
+export default function SelectLevelPage() {
+  const cfg = loadContentConfig();
+  return (
+    <AppShell>
+      <div className="space-y-4 max-w-xl w-full">
+        <h2 className="text-xl font-title">Kies een niveau</h2>
+        <ul className="space-y-2">
+          {cfg.levels.map((lvl) => (
+            <li key={lvl.id}>
+              <Link
+                className="block p-4 bg-white shadow rounded hover:bg-slate-50"
+                to={`/units/${lvl.id}`}
+              >
+                {lvl.label}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </AppShell>
+  );
+}
+

--- a/frontend-react/src/pages/SelectUnitPage.tsx
+++ b/frontend-react/src/pages/SelectUnitPage.tsx
@@ -1,0 +1,37 @@
+import AppShell from '@/components/layout/AppShell';
+import { loadContentConfig } from '@/lib/contentConfig';
+import { useParams, Link } from 'react-router-dom';
+
+export default function SelectUnitPage() {
+  const { levelId } = useParams<{ levelId: string }>();
+  const cfg = loadContentConfig();
+  const level = cfg.levels.find((l) => l.id === levelId);
+  if (!level) return null;
+  return (
+    <AppShell>
+      <div className="space-y-4 max-w-xl w-full">
+        <h2 className="text-xl font-title">{level.label}</h2>
+        <ul className="space-y-2">
+          {level.units.map((u) => (
+            <li key={u.id} className="p-4 bg-white shadow rounded">
+              <div className="font-semibold">Eenheid {u.label}</div>
+              <div className="text-sm text-slate-600">
+                Klanken: {u.focus_phonemes.join(', ')}
+              </div>
+              <div className="text-sm text-slate-600">
+                Voorbeelden: {u.word_bank.slice(0, 3).join(', ')}
+              </div>
+              <Link
+                to={`/session/${level.id}/${u.id}`}
+                className="inline-block mt-2 px-3 py-1 bg-primary text-white rounded"
+              >
+                Start
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </AppShell>
+  );
+}
+

--- a/frontend-react/src/pages/SessionPage.tsx
+++ b/frontend-react/src/pages/SessionPage.tsx
@@ -1,0 +1,45 @@
+import { useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import AppShell from '@/components/layout/AppShell';
+import { loadContentConfig } from '@/lib/contentConfig';
+import { generateTurn } from '@/lib/storyGenerator';
+
+function allowedFor(levelId: string, unitId: string) {
+  const cfg = loadContentConfig();
+  const level = cfg.levels.find((l) => l.id === levelId);
+  if (!level) return { level: undefined, unit: undefined, allowed: [] };
+  const idx = level.units.findIndex((u) => u.id === unitId);
+  const allowed = level.units.slice(0, idx + 1).flatMap((u) => u.focus_phonemes);
+  return { level, unit: level.units[idx], allowed };
+}
+
+export default function SessionPage() {
+  const { levelId, unitId } = useParams<{ levelId: string; unitId: string }>();
+  const navigate = useNavigate();
+  useEffect(() => {
+    async function run() {
+      if (!levelId || !unitId) return;
+      const { level, unit, allowed } = allowedFor(levelId, unitId);
+      if (!level || !unit) return;
+      const data = await generateTurn({
+        theme: 'demo',
+        level,
+        unit,
+        allowedGraphemes: allowed,
+      });
+      localStorage.setItem('story_data', JSON.stringify([
+        ...data.sentences.map((s) => ({ type: 'sentence', text: s })),
+        { type: 'direction', text: data.directions[0] },
+        { type: 'direction', text: data.directions[1] },
+      ]));
+      navigate('/story');
+    }
+    run();
+  }, [levelId, unitId, navigate]);
+  return (
+    <AppShell>
+      <div className="max-w-md w-full text-center">Voorbereiden…</div>
+    </AppShell>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add typed content configuration for Dutch early reading track
- implement decodability guard, fallback story builder, and mastery/adaptivity utilities
- provide generator service and minimal UI to select levels/units and run sessions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c33ad5e4c83278c1c3ba669204ad4