### PR TITLE
Load OpenAI API key from root env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ webapp/backend/storage/
 # React build artefacts
 frontend-react/dist
 
+# Local environment files
+.env
+
 # Ignore sample audio assets
 samples/
 *.wav

--- a/frontend-react/README.md
+++ b/frontend-react/README.md
@@ -21,6 +21,17 @@ Levels and themes are currently derived from
 these, update `src/lib/themeData.ts` to fetch them dynamically and adjust
 `LevelMap`/`LevelPage` accordingly.
 
+## Environment variables
+
+Add your OpenAI key to the repository's root `.env` file:
+
+```
+OPENAI_API_KEY=<your OpenAI API key>
+```
+
+Vite is configured to load this variable from the project root and expose it
+to the client.
+
 ### Scripts
 
 - `npm run dev` – development server

--- a/frontend-react/src/lib/storyGenerator.ts
+++ b/frontend-react/src/lib/storyGenerator.ts
@@ -77,7 +77,10 @@ export async function generateTurn({
     focus,
   });
 
-  const client = new OpenAI();
+  const client = new OpenAI({
+    apiKey: import.meta.env.OPENAI_API_KEY,
+    dangerouslyAllowBrowser: true,
+  });
 
   async function callModel() {
     const res = await client.responses.parse({

--- a/frontend-react/vite.config.ts
+++ b/frontend-react/vite.config.ts
@@ -6,6 +6,8 @@ import { fileURLToPath, URL } from 'url';
 export default defineConfig({
   plugins: [react()],
   base: '/static/react/',
+  envDir: '..',
+  envPrefix: ['VITE_', 'OPENAI_'],
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),


### PR DESCRIPTION
## Summary
- expose root `.env` to Vite and allow `OPENAI_` variables
- read `OPENAI_API_KEY` in story generator
- document root env setup and provide `.env.example`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c3e3abfcc8327bba5b30f9eb7e10d