### PR TITLE
Fix OpenAI Responses usage in story generator

### DIFF
--- a/frontend-react/src/lib/storyGenerator.ts
+++ b/frontend-react/src/lib/storyGenerator.ts
@@ -91,7 +91,7 @@ export async function generateTurn({
         { role: 'system', content: SYSTEM_MESSAGE },
         { role: 'user', content: userPrompt },
       ],
-      response_format: SCHEMA,
+      text: { response_format: SCHEMA },
     });
     type OutputItem = { content?: Array<{ text?: string }> };
     return (res.output[0] as OutputItem)?.content?.[0]?.text;


### PR DESCRIPTION
## Summary
- fix OpenAI Responses API call in story generator to use `text.response_format`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c42f0c92883278558bf151245ea4b