### PR TITLE
Generate word-level TTS for AVI sessions

### DIFF
--- a/frontend-react/src/pages/SessionPage.tsx
+++ b/frontend-react/src/pages/SessionPage.tsx
@@ -36,11 +36,21 @@ export default function SessionPage() {
         const j = (await res.json()) as { audio: string };
         return j.audio;
       }
+      async function ttsWord(text: string) {
+        const res = await fetch('/api/tts_word', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ text }),
+        });
+        const j = (await res.json()) as { audio: string };
+        return j.audio;
+      }
       const sentences = await Promise.all(
         data.sentences.map(async (s) => ({
           type: 'sentence' as const,
           text: s,
           audio: await tts(s),
+          words: await Promise.all(s.split(/\s+/).map((w) => ttsWord(w))),
         })),
       );
       const directions = await Promise.all(
@@ -48,6 +58,7 @@ export default function SessionPage() {
           type: 'direction' as const,
           text: d,
           audio: await tts(d),
+          words: await Promise.all(d.split(/\s+/).map((w) => ttsWord(w))),
         })),
       );
       localStorage.setItem('story_data', JSON.stringify([...sentences, ...directions]));

--- a/webapp/backend/main.py
+++ b/webapp/backend/main.py
@@ -365,6 +365,17 @@ async def generate_tts(payload: dict):
     return {"audio": os.path.basename(audio_path)}
 
 
+@app.post("/api/tts_word")
+async def generate_tts_word(payload: dict):
+    """Generate word-level TTS audio for the given text and return the filename."""
+    text = payload.get("text") if isinstance(payload, dict) else None
+    if not text:
+        raise HTTPException(status_code=400, detail="Missing text")
+    from .tts import word_tts_to_file
+    audio_path = await asyncio.to_thread(word_tts_to_file, text)
+    return {"audio": os.path.basename(audio_path)}
+
+
 @app.post("/api/realtime/start")
 async def realtime_start(
     sentence: str = Form(...),


### PR DESCRIPTION
## Summary
- add `/api/tts_word` endpoint for single-word speech synthesis
- pre-generate word audio in AVI SessionPage so word clicks speak

## Testing
- `python -m py_compile webapp/backend/main.py`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c511675dc832799612c4ff49811b8