### PR TITLE
feat: add shimmer effect for preparation text

### DIFF
--- a/frontend-react/src/pages/ContinuePage.tsx
+++ b/frontend-react/src/pages/ContinuePage.tsx
@@ -5,6 +5,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { BookOpen } from 'lucide-react';
 import type { StoryItem } from '@/components/story/SentenceDisplay';
+import { ShimmerText } from '@/components/ShimmerText';
 
 export default function ContinuePage() {
   const [progress, setProgress] = useState(0);
@@ -52,7 +53,9 @@ export default function ContinuePage() {
   return (
     <AppShell>
       <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="space-y-6 w-full max-w-md text-center">
-        <h2 className="font-title text-xl">Voorbereiden…</h2>
+        <h2 className="font-title text-xl">
+          <ShimmerText text="Voorbereiden…" />
+        </h2>
         <div className="flex justify-center">
           <motion.div animate={{ rotate: 360 }} transition={{ repeat: Infinity, duration: 2, ease: 'linear' }}>
             <BookOpen className="h-12 w-12 text-primary" />

--- a/frontend-react/src/pages/PlayPage.tsx
+++ b/frontend-react/src/pages/PlayPage.tsx
@@ -5,6 +5,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { useAuthStore } from '@/lib/useAuthStore';
 import { motion } from 'framer-motion';
 import { BookOpen } from 'lucide-react';
+import { ShimmerText } from '@/components/ShimmerText';
 
 export default function PlayPage() {
   const { levelId, themeId } = useParams<{ levelId: string; themeId: string }>();
@@ -44,7 +45,9 @@ export default function PlayPage() {
   return (
     <AppShell>
       <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="space-y-6 w-full max-w-md text-center">
-        <h2 className="font-title text-xl">Voorbereiden…</h2>
+        <h2 className="font-title text-xl">
+          <ShimmerText text="Voorbereiden…" />
+        </h2>
         <div className="flex justify-center">
           <motion.div animate={{ rotate: 360 }} transition={{ repeat: Infinity, duration: 2, ease: 'linear' }}>
             <BookOpen className="h-12 w-12 text-primary" />

--- a/frontend-react/src/pages/SessionPage.tsx
+++ b/frontend-react/src/pages/SessionPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import AppShell from '@/components/layout/AppShell';
 import { loadContentConfig } from '@/lib/contentConfig';
 import { generateTurn } from '@/lib/storyGenerator';
+import { ShimmerText } from '@/components/ShimmerText';
 
 function allowedFor(levelId: string, unitId: string) {
   const cfg = loadContentConfig();
@@ -68,7 +69,9 @@ export default function SessionPage() {
   }, [levelId, unitId, navigate]);
   return (
     <AppShell>
-      <div className="max-w-md w-full text-center">Voorbereiden…</div>
+      <div className="max-w-md w-full text-center">
+        <ShimmerText text="Voorbereiden…" />
+      </div>
     </AppShell>
   );
 }


### PR DESCRIPTION
## Summary
- add ShimmerText component to preparation messages in PlayPage, ContinuePage, and SessionPage

## Testing
- `cd frontend-react && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c54b22b208327b537d1fba566a573