### PR TITLE
Enhance story generator with focus klanken handling

### DIFF
--- a/frontend-react/src/pages/SessionPage.tsx
+++ b/frontend-react/src/pages/SessionPage.tsx
@@ -48,6 +48,8 @@ export default function SessionPage() {
           allowedGraphemes,
           allowedPatterns,
           maxWords,
+          chosenDirection: 'start',
+          storySoFar: '',
         });
         async function tts(text: string) {
           const res = await fetch('/api/tts', {


### PR DESCRIPTION
## Summary
- require story generator to include unit focus klanken and allow prior ones
- persist generation parameters and build unified prompts for start and continue
- align backend prompt builder and ensure JSON output handling

## Testing
- `npm test`
- `npm run lint`
- `python -m py_compile webapp/backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_689dc91f238c83279afa616c9117a5fb