### PR TITLE
Fix story generator OpenAI parameters

### DIFF
--- a/frontend-react/src/lib/storyGenerator.ts
+++ b/frontend-react/src/lib/storyGenerator.ts
@@ -82,10 +82,7 @@ export async function generateTurn({
     model: 'gpt-4o',
     temperature: 1.0,
     top_p: 1.0,
-    presence_penalty: 0,
-    frequency_penalty: 0,
     max_output_tokens: 300,
-    response_format: { type: 'json_object' },
     input: [
       { role: 'system', content: SYSTEM_MESSAGE },
       { role: 'user', content: userPrompt },


### PR DESCRIPTION
## Summary
- remove unsupported penalties and response_format from story generator

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689de06ab8c883279ea3900552bf2510