### PR TITLE
Ensure focus klanken appear at least three times

### DIFF
--- a/frontend-react/src/lib/storyGenerator.ts
+++ b/frontend-react/src/lib/storyGenerator.ts
@@ -129,7 +129,7 @@ function buildFocusLines(focusList: string[]): string[] {
   if (n === 0) return [];
   if (n <= 2) {
     return [
-      `• Focusklanken (moeten voorkomen, elk ten minste één keer): [${uniq.join(', ')}]`,
+      `• Focusklanken (laat ze samen minstens drie keer terugkomen, elk ten minste één keer): [${uniq.join(', ')}]`,
       '  Voorbeeld: gebruik de lettergroep zichtbaar in een woord.',
     ];
   }

--- a/webapp/backend/main.py
+++ b/webapp/backend/main.py
@@ -153,7 +153,7 @@ def _build_focus_lines(focus_list: list[str]) -> list[str]:
         return []
     if n <= 2:
         return [
-            f"• Focusklanken (moeten voorkomen, elk ten minste één keer): [{', '.join(uniq)}]",
+            f"• Focusklanken (laat ze samen minstens drie keer terugkomen, elk ten minste één keer): [{', '.join(uniq)}]",
             "  Voorbeeld: gebruik de lettergroep zichtbaar in een woord.",
         ]
     need = min(3, n)


### PR DESCRIPTION
## Summary
- Require a minimum of three total occurrences of focus klanken when generating sentences
- Mirror the updated focus-klank rule in both backend prompt builder and frontend story generator

## Testing
- `pytest`
- `cd frontend-react && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689de75c3538832786959d3c72a54eaa