### PR TITLE
Refactor reading modes and prompts per level

### DIFF
--- a/frontend-react/src/__tests__/decodability.mastery.test.ts
+++ b/frontend-react/src/__tests__/decodability.mastery.test.ts
@@ -3,10 +3,10 @@ import { MasteryTracker } from '@/lib/mastery';
 import { CONTENT_CONFIG } from '@/lib/contentConfig';
 
 test('decodability rejects disallowed digraph', () => {
-  const unit = CONTENT_CONFIG.levels[0].units[0];
-  const allowed = unit.focus_phonemes;
+  const unit = CONTENT_CONFIG.levels[0].units[3];
+  const allowed = unit.focus_klanken;
   expect(
-    isDecodable('ik speel ui.', allowed, unit.allowed_patterns, unit.sentence_rules.max_words),
+    isDecodable('ik speel ui.', allowed, unit.allowed_patterns, unit.sentence_rules!.max_words),
   ).toBe(false);
 });
 
@@ -14,14 +14,14 @@ test('decodability enforces word limit', () => {
   const unit = CONTENT_CONFIG.levels[0].units[3]; // unit D
   const allowed = CONTENT_CONFIG.levels[0].units
     .slice(0, 4)
-    .flatMap((u) => u.focus_phonemes);
+    .flatMap((u) => u.focus_klanken);
   const longSentence = 'huis weg bos tak hut boom';
   expect(
     isDecodable(
       longSentence,
       allowed,
       unit.allowed_patterns,
-      unit.sentence_rules.max_words,
+      unit.sentence_rules!.max_words,
     ),
   ).toBe(false);
 });

--- a/frontend-react/src/lib/contentConfig.ts
+++ b/frontend-react/src/lib/contentConfig.ts
@@ -17,11 +17,13 @@ export type UnitId =
   | 'K'
   | 'L';
 
+export type Mode = 'words' | 'story';
+
 export interface SentenceRules {
-  present: boolean; // always true
-  max_words: number;
+  present: true;
   punctuation: 'period_only';
-  allow_names: boolean;
+  max_words: number;
+  focus_usage_min?: number;
 }
 
 export interface MasteryThresholds {
@@ -33,12 +35,14 @@ export interface MasteryThresholds {
 export interface UnitSpec {
   id: UnitId;
   label: string;
-  focus_phonemes: string[];
+  mode: Mode;
+  strict_forbid: boolean;
+  focus_klanken: string[];
   allowed_patterns: string[];
   word_bank: string[];
-  sentence_rules: SentenceRules;
-  starts_sentences: boolean;
-  mastery_thresholds: MasteryThresholds;
+  sentence_rules?: SentenceRules;
+  starts_sentences?: boolean;
+  mastery_thresholds?: MasteryThresholds;
 }
 
 export interface LevelSpec {
@@ -64,59 +68,49 @@ export const CONTENT_CONFIG: ContentConfig = {
         {
           id: 'A',
           label: 'A',
-          focus_phonemes: ['m', 'r', 'v', 'i', 's', 'aa', 'p', 'e'],
+          mode: 'words',
+          strict_forbid: true,
+          focus_klanken: ['m', 'r', 'v', 'i', 's', 'aa', 'p', 'e'],
           allowed_patterns: ['CV', 'CVC'],
           word_bank: ['ik', 'maan', 'roos', 'vis', 'pen', 'aan', 'en', 'sok'],
-          sentence_rules: {
-            present: true,
-            max_words: 6,
-            punctuation: 'period_only',
-            allow_names: true,
-          },
           starts_sentences: false,
           mastery_thresholds: { accuracy: 0.93, sessions: 2 },
         },
         {
           id: 'B',
           label: 'B',
-          focus_phonemes: ['t', 'n', 'b', 'oo', 'ee'],
+          mode: 'words',
+          strict_forbid: true,
+          focus_klanken: ['t', 'n', 'b', 'oo', 'ee'],
           allowed_patterns: ['CV', 'CVC', 'CVCC'],
           word_bank: ['teen', 'een', 'neus', 'buik', 'oog'],
-          sentence_rules: {
-            present: true,
-            max_words: 6,
-            punctuation: 'period_only',
-            allow_names: true,
-          },
           starts_sentences: false,
           mastery_thresholds: { accuracy: 0.93, sessions: 2 },
         },
         {
           id: 'C',
           label: 'C',
-          focus_phonemes: ['d', 'oe', 'k', 'ij', 'z'],
+          mode: 'words',
+          strict_forbid: true,
+          focus_klanken: ['d', 'oe', 'k', 'ij', 'z'],
           allowed_patterns: ['CV', 'CVC', 'CVCC'],
           word_bank: ['doos', 'poes', 'koek', 'ijs', 'zeep'],
-          sentence_rules: {
-            present: true,
-            max_words: 6,
-            punctuation: 'period_only',
-            allow_names: true,
-          },
           starts_sentences: false,
           mastery_thresholds: { accuracy: 0.93, sessions: 2 },
         },
         {
           id: 'D',
           label: 'D',
-          focus_phonemes: ['h', 'w', 'o', 'a', 'u'],
+          mode: 'story',
+          strict_forbid: false,
+          focus_klanken: ['h', 'w', 'o', 'a', 'u'],
           allowed_patterns: ['CV', 'CVC', 'CVCC'],
           word_bank: ['huis', 'weg', 'bos', 'tak', 'hut'],
           sentence_rules: {
             present: true,
-            max_words: 7,
             punctuation: 'period_only',
-            allow_names: true,
+            max_words: 7,
+            focus_usage_min: 3,
           },
           starts_sentences: true,
           mastery_thresholds: { accuracy: 0.93, sessions: 2 },
@@ -124,14 +118,16 @@ export const CONTENT_CONFIG: ContentConfig = {
         {
           id: 'E',
           label: 'E',
-          focus_phonemes: ['eu', 'j', 'ie', 'l', 'ou', 'uu'],
+          mode: 'story',
+          strict_forbid: false,
+          focus_klanken: ['eu', 'j', 'ie', 'l', 'ou', 'uu'],
           allowed_patterns: ['CV', 'CVC', 'CVCC', 'CCVC'],
           word_bank: ['reus', 'jas', 'riem', 'bijl', 'hout', 'vuur'],
           sentence_rules: {
             present: true,
-            max_words: 7,
             punctuation: 'period_only',
-            allow_names: true,
+            max_words: 7,
+            focus_usage_min: 3,
           },
           starts_sentences: true,
           mastery_thresholds: { accuracy: 0.93, sessions: 2 },
@@ -139,14 +135,16 @@ export const CONTENT_CONFIG: ContentConfig = {
         {
           id: 'F',
           label: 'F',
-          focus_phonemes: ['g', 'ui', 'au', 'f', 'ei'],
+          mode: 'story',
+          strict_forbid: false,
+          focus_klanken: ['g', 'ui', 'au', 'f', 'ei'],
           allowed_patterns: ['CV', 'CVC', 'CVCC', 'CCVC'],
           word_bank: ['geit', 'pauw', 'duif', 'ei'],
           sentence_rules: {
             present: true,
-            max_words: 7,
             punctuation: 'period_only',
-            allow_names: true,
+            max_words: 7,
+            focus_usage_min: 3,
           },
           starts_sentences: true,
           mastery_thresholds: { accuracy: 0.93, sessions: 2 },
@@ -154,14 +152,16 @@ export const CONTENT_CONFIG: ContentConfig = {
         {
           id: 'G',
           label: 'G',
-          focus_phonemes: ['sch', 'ng'],
+          mode: 'story',
+          strict_forbid: false,
+          focus_klanken: ['sch', 'ng'],
           allowed_patterns: ['CV', 'CVC', 'CCVC', 'CVCC'],
           word_bank: ['kist', 'drop', 'hond', 'slang', 'bank', 'springt', 'meeuw', 'ja', 'zo'],
           sentence_rules: {
             present: true,
-            max_words: 8,
             punctuation: 'period_only',
-            allow_names: true,
+            max_words: 7,
+            focus_usage_min: 3,
           },
           starts_sentences: true,
           mastery_thresholds: { accuracy: 0.93, sessions: 2 },
@@ -169,14 +169,16 @@ export const CONTENT_CONFIG: ContentConfig = {
         {
           id: 'H',
           label: 'H',
-          focus_phonemes: ['nk', 'ch'],
+          mode: 'story',
+          strict_forbid: false,
+          focus_klanken: ['nk', 'ch'],
           allowed_patterns: ['CV', 'CVC', 'CCVC', 'CVCC'],
           word_bank: ['bank', 'licht'],
           sentence_rules: {
             present: true,
-            max_words: 8,
             punctuation: 'period_only',
-            allow_names: true,
+            max_words: 7,
+            focus_usage_min: 3,
           },
           starts_sentences: true,
           mastery_thresholds: { accuracy: 0.93, sessions: 2 },
@@ -184,14 +186,16 @@ export const CONTENT_CONFIG: ContentConfig = {
         {
           id: 'I',
           label: 'I',
-          focus_phonemes: ['aai', 'ooi', 'oei'],
+          mode: 'story',
+          strict_forbid: false,
+          focus_klanken: ['aai', 'ooi', 'oei'],
           allowed_patterns: ['CV', 'CVC', 'CCVC', 'CVCC'],
           word_bank: ['kraai', 'kooi', 'groei'],
           sentence_rules: {
             present: true,
-            max_words: 8,
             punctuation: 'period_only',
-            allow_names: true,
+            max_words: 7,
+            focus_usage_min: 3,
           },
           starts_sentences: true,
           mastery_thresholds: { accuracy: 0.93, sessions: 2 },
@@ -199,14 +203,16 @@ export const CONTENT_CONFIG: ContentConfig = {
         {
           id: 'J',
           label: 'J',
-          focus_phonemes: ['ieuw', 'eeuw', 'uw'],
+          mode: 'story',
+          strict_forbid: false,
+          focus_klanken: ['ieuw', 'eeuw', 'uw'],
           allowed_patterns: ['CV', 'CVC', 'CCVC', 'CVCC'],
           word_bank: ['nieuw', 'leeuw', 'uw'],
           sentence_rules: {
             present: true,
-            max_words: 9,
             punctuation: 'period_only',
-            allow_names: true,
+            max_words: 7,
+            focus_usage_min: 3,
           },
           starts_sentences: true,
           mastery_thresholds: { accuracy: 0.93, sessions: 2 },
@@ -214,14 +220,16 @@ export const CONTENT_CONFIG: ContentConfig = {
         {
           id: 'K',
           label: 'K',
-          focus_phonemes: ['vr', 'sl', '-lijk', '-tig', '-ing'],
+          mode: 'story',
+          strict_forbid: false,
+          focus_klanken: ['vr', 'sl', '-lijk', '-tig', '-ing'],
           allowed_patterns: ['CV', 'CVC', 'CCVC', 'CVCC'],
           word_bank: ['vragen', 'spelen', 'schotel', 'sturen', 'moeilijk', 'koning'],
           sentence_rules: {
             present: true,
-            max_words: 9,
             punctuation: 'period_only',
-            allow_names: true,
+            max_words: 7,
+            focus_usage_min: 3,
           },
           starts_sentences: true,
           mastery_thresholds: { accuracy: 0.93, sessions: 2 },
@@ -229,14 +237,16 @@ export const CONTENT_CONFIG: ContentConfig = {
         {
           id: 'L',
           label: 'L',
-          focus_phonemes: ['consolideer'],
+          mode: 'story',
+          strict_forbid: false,
+          focus_klanken: ['consolideer'],
           allowed_patterns: ['CV', 'CVC', 'CCVC', 'CVCC'],
           word_bank: [],
           sentence_rules: {
             present: true,
-            max_words: 9,
             punctuation: 'period_only',
-            allow_names: true,
+            max_words: 7,
+            focus_usage_min: 3,
           },
           starts_sentences: true,
           mastery_thresholds: { accuracy: 0.93, sessions: 2 },

--- a/frontend-react/src/lib/storyGenerator.ts
+++ b/frontend-react/src/lib/storyGenerator.ts
@@ -1,143 +1,53 @@
-// Simplified story generation service relying on model quality
-
-import OpenAI from 'openai';
-export interface GenerateOptions {
+export async function generateWords(params: {
+  levelId: string;
+  unitId: string;
   focusGraphemes: string[];
   allowedGraphemes: string[];
   allowedPatterns: string[];
-  maxWords: number;
-  chosenDirection: string;
-  storySoFar?: string;
+}) {
+  const res = await fetch('/api/generate_words', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      level: params.levelId,
+      unit: params.unitId,
+      focus: params.focusGraphemes,
+      allowed: params.allowedGraphemes,
+      patterns: params.allowedPatterns,
+    }),
+  });
+  if (!res.ok) throw new Error('word generation failed');
+  return (await res.json()) as { words: string[] };
+}
+
+export async function generateStory(params: {
   theme?: string;
-  temperature?: number;
-}
-
-const SYSTEM_MESSAGE = `Je bent een Nederlandse verhalenmaker voor jonge kinderen (4–8 jaar).
-
-Stijl (houd je hieraan):
-• Eenvoudig, kindvriendelijk Nederlands in de tegenwoordige tijd.
-• Korte zinnen: 3–8 woorden (of korter als nodig).
-• Alleen een punt (.) aan het einde van elke zin.
-• Namen zijn toegestaan; als je een naam gebruikt, houd die consequent.
-
-Structuur per beurt:
-• Vijf zinnen vormen samen één mini-scène.
-• Zin 1–2 voeren de gekozen richting echt uit.
-• Daarna geef je precies twee korte richtingzinnen (keuzes), gebiedende wijs, 2–4 woorden, parallel en betekenisvol.
-
-Uitvoer = ÉÉN JSON-object en verder niets:
-{
-  "sentences": [5 korte zinnen],
-  "directions": [2 korte keuzes]
-}
-Geen uitleg, geen extra tekst, geen markdown.`;
-
-export async function generateTurn({
-  focusGraphemes,
-  allowedGraphemes,
-  allowedPatterns,
-  maxWords,
-  chosenDirection,
-  storySoFar,
-  theme,
-  temperature = 0.9,
-}: GenerateOptions) {
-  const userPrompt = buildUserPrompt({
-    chosenDirection,
-    storySoFar,
-    theme,
-    focusGraphemes,
-    allowedGraphemes,
-    allowedPatterns,
-    maxWords,
-  });
-
-  if (import.meta.env.DEV) {
-    console.log('System message:', SYSTEM_MESSAGE);
-    console.log('User message:', userPrompt);
-  }
-
-  const client = new OpenAI({
-    apiKey: import.meta.env.OPENAI_API_KEY,
-    dangerouslyAllowBrowser: true,
-  });
-
-  const res = await client.responses.create({
-    model: 'gpt-4o',
-    temperature,
-    top_p: 1.0,
-    max_output_tokens: 300,
-    input: [
-      { role: 'system', content: SYSTEM_MESSAGE },
-      { role: 'user', content: userPrompt },
-    ],
-    text: { format: { type: 'json_object' } },
-  });
-
-  const json = res.output_text;
-  if (!json) throw new Error('empty response');
-  return JSON.parse(json) as {
-    sentences: string[];
-    directions: string[];
-  };
-}
-
-function buildUserPrompt(opts: {
-  theme?: string;
+  levelId: string;
+  unitId: string;
   chosenDirection: string;
   storySoFar?: string;
   focusGraphemes: string[];
   allowedGraphemes: string[];
   allowedPatterns: string[];
   maxWords: number;
-}): string {
-  const {
-    theme,
-    chosenDirection,
-    storySoFar,
-    focusGraphemes,
-    allowedGraphemes,
-    allowedPatterns,
-    maxWords,
-  } = opts;
-
-  const focusLines = buildFocusLines(focusGraphemes);
-
-  const parts = [
-    `Thema (optioneel): ${theme ?? ''}`,
-    `Richting die is gekozen (vorige stap): ${chosenDirection}`,
-    `Verhaal tot nu toe (optioneel): "${storySoFar ?? ''}"`,
-    '',
-    'Beperkingen voor deze stap (houd het natuurlijk):',
-    ...focusLines,
-    `• Je mag daarnaast ook andere letters/klanken gebruiken die al geleerd zijn: [${allowedGraphemes.join(', ')}]`,
-    `• Woordpatronen (informatief): [${allowedPatterns.join(', ')}]`,
-    `• Maximaal ${maxWords} woorden per zin`,
-    '',
-    'Schrijf vijf korte, kindvriendelijke zinnen die logisch doorgaan.',
-    'Zin 1–2 voeren de gekozen richting echt uit.',
-    'Geef daarna precies twee nieuwe keuzes (gebiedende wijs, 2–4 woorden).',
-  ];
-
-  return parts.join('\n');
+  strictForbid: boolean;
+}) {
+  const res = await fetch('/api/continue_story', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      theme: params.theme,
+      level: params.levelId,
+      unit: params.unitId,
+      direction: params.chosenDirection,
+      story: params.storySoFar,
+      focus: params.focusGraphemes,
+      allowed: params.allowedGraphemes,
+      patterns: params.allowedPatterns,
+      max_words: params.maxWords,
+      strict_forbid: params.strictForbid,
+    }),
+  });
+  if (!res.ok) throw new Error('story generation failed');
+  return (await res.json()) as { sentences: string[]; directions: string[] };
 }
-
-function buildFocusLines(focusList: string[]): string[] {
-  const focusItems = focusList.map((x) => x.trim()).filter(Boolean);
-  const uniq = Array.from(new Set(focusItems));
-  const n = uniq.length;
-  if (n === 0) return [];
-  if (n <= 2) {
-    return [
-      `• Focusklanken (laat ze samen minstens drie keer terugkomen, elk ten minste één keer): [${uniq.join(', ')}]`,
-      '  Voorbeeld: gebruik de lettergroep zichtbaar in een woord.',
-    ];
-  }
-  const need = Math.min(3, n);
-  return [
-    `• Focusklanken (laat minstens ${need} verschillende items terugkomen): [${uniq.join(', ')}]`,
-    "  Voorbeeld: 'maan' bevat [aa], 'bank' bevat [nk].",
-  ];
-}
-
-

--- a/frontend-react/src/pages/ContinuePage.tsx
+++ b/frontend-react/src/pages/ContinuePage.tsx
@@ -21,6 +21,7 @@ export default function ContinuePage() {
     const allowed = localStorage.getItem('allowed') ?? '';
     const patterns = localStorage.getItem('patterns') ?? '';
     const maxWords = localStorage.getItem('max_words') ?? '';
+    const strictForbid = localStorage.getItem('strict_forbid') ?? '';
     const storySoFar = JSON.parse(localStorage.getItem('story_data') ?? '[]')
       .filter((i: StoryItem) => i.type === 'sentence')
       .map((i: StoryItem) => i.text)
@@ -32,7 +33,7 @@ export default function ContinuePage() {
     }
 
     const ev = new EventSource(
-      `/api/continue_story?theme=${theme}&level=${level}&direction=${encodeURIComponent(direction)}&story=${encodeURIComponent(storySoFar)}&focus=${encodeURIComponent(focus)}&allowed=${encodeURIComponent(allowed)}&patterns=${encodeURIComponent(patterns)}&max_words=${maxWords}`,
+      `/api/continue_story?theme=${theme}&level=${level}&direction=${encodeURIComponent(direction)}&story=${encodeURIComponent(storySoFar)}&focus=${encodeURIComponent(focus)}&allowed=${encodeURIComponent(allowed)}&patterns=${encodeURIComponent(patterns)}&max_words=${maxWords}&strict_forbid=${strictForbid}`,
     );
     const data: StoryItem[] = [];
 

--- a/frontend-react/src/pages/SelectUnitPage.tsx
+++ b/frontend-react/src/pages/SelectUnitPage.tsx
@@ -16,7 +16,7 @@ export default function SelectUnitPage() {
             <li key={u.id} className="p-4 bg-white shadow rounded">
               <div className="font-semibold">Eenheid {u.label}</div>
               <div className="text-sm text-slate-600">
-                Klanken: {u.focus_phonemes.join(', ')}
+                Klanken: {u.focus_klanken.join(', ')}
               </div>
               <div className="text-sm text-slate-600">
                 Voorbeelden: {u.word_bank.slice(0, 3).join(', ')}


### PR DESCRIPTION
## Summary
- introduce per-unit `words` and `story` modes with strict forbid support
- add backend routes and prompt builders for level-aware word and story generation
- gate frontend session flow by mode and persist generation constraints

## Testing
- `npm test`
- `npm run lint`
- `python -m py_compile webapp/backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0859ba4808327a3a90c511d153736